### PR TITLE
Fix pipeline support

### DIFF
--- a/optimum/amd/ryzenai/modeling.py
+++ b/optimum/amd/ryzenai/modeling.py
@@ -142,7 +142,7 @@ class RyzenAIModel(OptimizedModel):
         raise NotImplementedError
 
     def to(self, device: Union[torch.device, str, int]):
-        # Necessary for compatibility with transformer pipelines 
+        # Necessary for compatibility with transformer pipelines
         return self
 
     @staticmethod


### PR DESCRIPTION
Fix below error post Transformers: 4.37.1

```
NotImplementedError: Setting device for RyzenAi is not supported!
```