### PR TITLE
Quantization & ONNX export through Brevitas

### DIFF
--- a/examples/quantization/brevitas/README.md
+++ b/examples/quantization/brevitas/README.md
@@ -1,0 +1,35 @@
+# Example of quantizing OPT model with Brevitas from Transformers checkpoints
+
+The example with shows an example on how to quantize an OPT model through Brevitas: 
+ - Instantiation of facebook's OPT model from HuggingFace transformers
+ - The definition and instantiation of a parametrizable `BrevitasQuantizer` which extends `OptimumQuantizer`
+ - Optional conversion of the OPT model to an FX representation, leveraging HuggingFace transformers' tracer
+ - Prototype support of executing PTQ algorithms and validation, while leveraging CPU offload from HuggingFace accelerate
+ - Quantization of the OPT model using Brevitas' PTQ algorithms
+   - Optionally converting the `OPTAttention` layer to `torch.nn.MultiheadAttention` for finer-grained quantization of MHA layers
+   - Optionally applying: SmoothQuant, GPTQ, weight equalization algorithms
+ - Validation of the quantized model
+ - (WIP) Export to quantized ONNX (QDQ-style), leveraging HuggingFace optimum's ONNX export
+
+## Prerequisites
+
+The examples were tested using:
+ - PyTorch v2.1.2
+ - transformers installed from main
+ - accelerate install from main
+ - optimum installed from main
+
+## Running the Example
+
+```bash
+python quantize_opt.py --apply-act-equalization fx --with-fx
+```
+To quantize OPT with the graph-based SmoothQuant PTQ algorithm enabled.
+
+For all the options, please check:
+
+```bash
+python quantize_opt.py --help
+```
+
+Most options can be applied independently.

--- a/examples/quantization/brevitas/quantize_opt.py
+++ b/examples/quantization/brevitas/quantize_opt.py
@@ -1,0 +1,87 @@
+from argparse import ArgumentParser
+
+import torch
+from brevitas.export.onnx.standard.qcdq.manager import StdQCDQONNXManager
+from brevitas_examples.llm.llm_quant.export import brevitas_proxy_export_mode
+
+from optimum.amd import BrevitasQuantizationConfig, BrevitasQuantizer
+from optimum.amd.brevitas.accelerate_utils import offload_model, remove_hooks
+from optimum.amd.brevitas.data_utils import get_dataset, model_eval_accelerate
+from optimum.exporters.onnx.__main__ import onnx_export  # TODO: move this method elsewhere (not __main__.py)
+from transformers import AutoTokenizer
+
+
+parser = ArgumentParser(description="Quantize OPT from 🤗 Transformers with AMD Brevitas")
+parser.add_argument(
+    "--model",
+    type=str,
+    default="facebook/opt-125m",
+    help="Model checkpoint to quantize. Can either be a local path to a model folder, or a model on Hugging Face Hub. Example: facebook/opt-125m",
+)
+parser.add_argument(
+    "--apply-gptq",
+    action="store_true",
+    default=False,
+    help="Apply the GPTQ algorithm during quantization (Note, currently slow!)",
+)
+parser.add_argument(
+    "--apply-weight-equalization", action="store_true", default=False, help="Apply the weight equalization algorithm"
+)
+
+# TODO: explain what fx and layerwise are.
+parser.add_argument(
+    "--apply-act-equalization",
+    type=str,
+    choices=[None, "fx", "layerwise"],
+    default=None,
+    help="Apply the activation equalization (SmoothQuant) algorithm (choices: [%(choices)s], default: %(default)s)",
+)
+parser.add_argument(
+    "--replace-mha-with-quantizable",
+    action="store_true",
+    default=False,
+    help="Replace attention with standard PyTorch implementation (default: %(default)s)",
+)
+
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(args.model)
+
+qconfig = BrevitasQuantizationConfig(
+    apply_gptq=args.apply_gptq,
+    apply_weight_equalization=args.apply_weight_equalization,
+    activations_equalization=args.apply_act_equalization,
+    replace_mha_with_quantizable=args.replace_mha_with_quantizable,
+)
+
+quantizer = BrevitasQuantizer.from_pretrained(args.model)
+
+# calibration_dataloader = quantizer.get_calibration_dataloader(
+#     tokenizer, dataset_name='wikitext2-raw', num_samples=qconfig.nsamples, seqlen=qconfig.seqlen)
+
+calibration_dataloader = get_dataset(
+    dataset_name="wikitext2", tokenizer=tokenizer, nsamples=128, seqlen=2048, split="train"
+)
+
+print("Apply quantization")
+# TODO: model should ideally not be passed to `quantize`.
+model = quantizer.quantize(qconfig, calibration_dataloader)
+print("Quantization applied")
+
+model = offload_model(model)
+print("Model eval...")
+
+validation_dataloader = get_dataset(
+    dataset_name="wikitext2", tokenizer=tokenizer, nsamples=128, seqlen=2048, split="validation"
+)
+
+perplexity = model_eval_accelerate(model, validation_dataloader, qconfig.seqlen)
+print(f"C4 perplexity: {perplexity}")
+
+print("Exporting the model to ONNX...")
+# When exporting to ONNX, Accelerate's hooks need to be removed otherwise we have unwanted Cast nodes in the ONNX graph.
+remove_hooks(model)
+
+# Export to ONNX through optimum.exporters.
+with torch.no_grad(), brevitas_proxy_export_mode(model, export_manager=StdQCDQONNXManager):
+    onnx_export(model, "opt_quantized_onnx", task="text-generation-with-past", do_validation=False)

--- a/optimum/amd/__init__.py
+++ b/optimum/amd/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+# Licensed under the MIT License.
+
+from .brevitas.configuration import BrevitasQuantizationConfig
+from .brevitas.quantizer import BrevitasQuantizer

--- a/optimum/amd/brevitas/accelerate_utils.py
+++ b/optimum/amd/brevitas/accelerate_utils.py
@@ -1,0 +1,393 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+# Licensed under the MIT License.
+
+import logging
+from typing import Dict, Optional, Union
+
+import brevitas.config as config
+import torch
+from accelerate import dispatch_model, infer_auto_device_map
+from accelerate.hooks import AlignDevicesHook, add_hook_to_module, remove_hook_from_module
+from accelerate.utils import (
+    check_tied_parameters_in_config,
+    compute_module_sizes,
+    find_device,
+    find_tied_parameters,
+    get_max_layer_size,
+    get_max_memory,
+    send_to_device,
+)
+from brevitas.graph.utils import get_module
+from brevitas.utils.python_utils import recurse_getattr
+from psutil import virtual_memory
+
+
+logger = logging.getLogger(__name__)
+
+
+def align_input(model, device_map):
+    if set(device_map.values()) == {"cpu"} or set(device_map.values()) == {"cpu", "disk"}:
+        main_device = "cpu"
+    else:
+        main_device = [d for d in device_map.values() if d not in ["cpu", "disk"]][0]
+    hook = AlignDevicesHook(execution_device=main_device, io_same_device=True, skip_keys=None, tied_params_map=None)
+    add_hook_to_module(model, hook)
+    return model
+
+
+# Adapted from accelerate.utils.modeling.infer_auto_device_map
+def infer_fx_auto_device_map(
+    model: torch.fx.GraphModule,
+    max_memory: Optional[Dict[Union[int, str], Union[int, str]]] = None,
+    dtype: Optional[Union[str, torch.dtype]] = None,
+    special_dtypes: Optional[Dict[str, Union[str, torch.dtype]]] = None,
+    verbose: bool = False,
+):
+    """
+    Extends accelerate's infer_auto_device_map function to be compatible with torch.fx.GraphModule.
+
+    The main modifications are:
+    - Work around the fact that module.__class__.__name__ is Module for everything
+    - We do not need to keep entire blocks together anymore, since we add a functional equivalent of the AlignDeviceHook
+    before every call function.
+    """
+    # TODO: Why no no_split_module_classes, clean_result parameters?
+
+    # Get default / clean up max_memory
+    max_memory = get_max_memory(max_memory)
+
+    devices = list(max_memory.keys())
+    if "disk" not in devices:
+        devices.append("disk")
+    gpus = [device for device in devices if device not in ["cpu", "disk"]]
+
+    # Devices that need to keep space for a potential offloaded layer.
+    if "mps" in gpus:
+        main_devices = ["mps"]
+    elif len(gpus) > 0:
+        main_devices = [gpus[0], "cpu"]
+    else:
+        main_devices = ["cpu"]
+
+    module_sizes = compute_module_sizes(model, dtype=dtype, special_dtypes=special_dtypes)
+    tied_parameters = find_tied_parameters(model)
+
+    if check_tied_parameters_in_config(model) and len(tied_parameters) == 0:
+        logger.warn(
+            "The model weights are not tied. Please use the `tie_weights` method before using the `infer_auto_device` function."
+        )
+
+    device_map = {}
+    current_device = 0
+    current_memory_used = 0
+
+    call_module_list = []
+    for node in model.graph.nodes:
+        if node.op == "call_module":
+            name = node.target
+            module = get_module(model, node.target)
+            call_module_list.append((name, module))
+
+    # Direct submodules and parameters
+    modules_to_treat = (
+        list(model.named_parameters(recurse=False)) + call_module_list + list(model.named_buffers(recurse=False))
+    )
+    # Initialize maximum largest layer, to know which space to keep in memory
+    max_layer_size, max_layer_names = get_max_layer_size(modules_to_treat, module_sizes, [])
+
+    # Ready ? This is going to be a bit messy.
+    while len(modules_to_treat) > 0:
+        name, module = modules_to_treat.pop(0)
+        if verbose:
+            print(f"\nTreating module {name}.")
+        # Max size in the remaining layers may have changed since we took one, so we maybe update it.
+        max_layer_names = [n for n in max_layer_names if n != name and not n.startswith(name + ".")]
+        if len(max_layer_names) == 0:
+            max_layer_size, max_layer_names = get_max_layer_size(
+                [(n, m) for n, m in modules_to_treat if isinstance(m, torch.nn.Module)], module_sizes, []
+            )
+        # Assess size needed
+        module_size = module_sizes[name]
+
+        # We keep relevant tied parameters only: one of the tied parameters in the group is inside the current module
+        # and the other is not.
+        tied_param_goups = [
+            tied_group
+            for tied_group in tied_parameters
+            if any(name + "." in k + "." for k in tied_group) and not all(name + "." in k + "." for k in tied_group)
+        ]
+
+        if verbose and len(tied_param_goups) > 0:
+            print(f"  Found the relevant tied param groups {tied_param_goups}")
+        # Then we keep track of all the parameters that are tied to the current module, but not in the current module
+        tied_params = sum(
+            [[p for p in tied_group if name + "." not in p + "."] for tied_group in tied_param_goups], []
+        )
+        if verbose and len(tied_params) > 0:
+            print(f"  So those parameters need to be taken into account {tied_params}")
+
+        device = devices[current_device]
+        current_max_size = max_memory[device] if device != "disk" else None
+        # Reduce max size available by the largest layer.
+        if devices[current_device] in main_devices:
+            current_max_size = current_max_size - max_layer_size
+        # Case 1 -> We're too big!
+        if current_max_size is not None and current_memory_used + module_size > current_max_size:
+            # For FX, we never split a leaf call_module
+            if verbose:
+                print(
+                    f"Not enough space on {devices[current_device]} to put {name} (space available "
+                    f"{current_max_size-current_memory_used}, module size {module_size})."
+                )
+
+            if verbose:
+                print("This module cannot be split, going to the next device.")
+            current_device += 1
+            modules_to_treat = [(name, module)] + modules_to_treat
+            current_memory_used = 0
+
+        # Case 2, it fits! We're not entirely out of the wood though, because we may have some tied parameters.
+        elif len(tied_params) > 0:
+            # First locate all tied modules
+            tied_module_names = []
+            tied_modules = []
+            for tied_param in tied_params:
+                tied_module_index = [i for i, (n, _) in enumerate(modules_to_treat) if n in tied_param][0]
+                tied_module_names.append(modules_to_treat[tied_module_index][0])
+                tied_modules.append(modules_to_treat[tied_module_index][1])
+            if verbose:
+                print(
+                    f"  It looks like {name} is going to fit on {devices[current_device]} but we have tied "
+                    f"parameters to account for.\n  - Names {tied_params}\n  - Module names {tied_module_names}"
+                )
+
+            # Let's see if it all fits first
+            module_size_with_ties = module_size
+            for tied_param, tied_module_name in zip(tied_params, tied_module_names):
+                module_size_with_ties += module_sizes[tied_module_name] - module_sizes[tied_param]
+
+            if current_max_size is None or current_memory_used + module_size_with_ties <= current_max_size:
+                # We really really fit!
+                if verbose:
+                    print(f"Putting {name} and {tied_module_names} on {devices[current_device]}.")
+                current_memory_used += module_size_with_ties
+                device_map[name] = devices[current_device]
+                for tied_module_name in tied_module_names:
+                    if tied_module_name in [m[0] for m in modules_to_treat]:
+                        # The module may have been removed by a previous iteration of this loop.
+                        tied_module_index = [i for i, (n, _) in enumerate(modules_to_treat) if n == tied_module_name][
+                            0
+                        ]
+                        modules_to_treat.pop(tied_module_index)
+                    device_map[tied_module_name] = devices[current_device]
+
+            else:
+                # We don't fit with the tied modules. Next question is: can we split one of the tied modules to make it
+                # smaller or do we need to go on the next device?
+                if verbose:
+                    print(
+                        f"Not enough space on {devices[current_device]} to put {name} and {tied_module_names} (space "
+                        f"available {current_max_size-current_memory_used}, needed size {module_size_with_ties})."
+                    )
+                split_happened = False
+                for tied_module_name, tied_module in zip(tied_module_names, tied_modules):
+                    tied_module_children = list(tied_module.named_children())
+                    if len(tied_module_children) == 0:
+                        # can't break this one.
+                        continue
+                    if verbose:
+                        print(f"Splitting {tied_module_name}.")
+                    tied_module_children = list(tied_module.named_parameters(recurse=False)) + tied_module_children
+                    tied_module_children = [(f"{tied_module_name}.{n}", v) for n, v in tied_module_children]
+                    tied_module_index = [i for i, (n, _) in enumerate(modules_to_treat) if n == tied_module_name][0]
+
+                    modules_to_treat = (
+                        [(name, module)]
+                        + modules_to_treat[:tied_module_index]
+                        + tied_module_children
+                        + modules_to_treat[tied_module_index + 1 :]
+                    )
+                    # Update the max layer size.
+                    max_layer_size, max_layer_names = get_max_layer_size(
+                        [(n, m) for n, m in modules_to_treat if isinstance(m, torch.nn.Module)],
+                        module_sizes,
+                        [],
+                    )
+                    split_happened = True
+                    break
+
+                if not split_happened:
+                    # If the tied module is not split, we go to the next device
+                    if verbose:
+                        print("None of the tied module can be split, going to the next device.")
+                    current_device += 1
+                    modules_to_treat = [(name, module)] + modules_to_treat
+                    current_memory_used = 0
+
+        else:
+            if verbose:
+                if current_max_size is None:
+                    print(f"Putting {name} (size={module_size}) on {devices[current_device]}.")
+                else:
+                    print(
+                        f"Putting {name} (size={module_size}) on {devices[current_device]} "
+                        f"(available={current_max_size-current_memory_used})."
+                    )
+            current_memory_used += module_size
+            device_map[name] = devices[current_device]
+
+    if len(set(device_map.values())) == 1:
+        device_map = {"": list(device_map.values())[0]}
+    return device_map
+
+
+def offload_call_function(
+    model: torch.fx.GraphModule, max_memory: Optional[Dict[Union[int, str], Union[int, str]]], device_map: Dict
+):
+    """
+    Attaches AlignDevicesHook to fx.GraphModule call_function nodes. Although accelerate's `offload_model` attaches hooks
+    to submodules, it is unable to detect call_function.
+
+    Returns:
+        device_map (`TODO`):
+            TODO
+    """
+    max_memory = get_max_memory(max_memory)
+    devices = list(max_memory.keys())
+
+    for node in model.graph.nodes:
+        if node.op == "call_function":
+
+            def new_func(*args, old_callable=node.target, **kwargs):
+                device = find_device([args, kwargs])
+                args = list(args)
+                original_args_device = []
+                original_kwargs_device = {}
+                for i, arg in enumerate(args):
+                    original_args_device.append(find_device(arg))
+                    args[i] = send_to_device(arg, device)
+                for k, v in kwargs.items():
+                    original_kwargs_device[k] = find_device(v)
+                    kwargs[k] = send_to_device(v, device)
+                out = old_callable(*args, **kwargs)
+
+                for i, arg in enumerate(args):
+                    args[i] = send_to_device(arg, original_args_device[i])
+                for k, v in kwargs.items():
+                    kwargs[k] = send_to_device(v, original_kwargs_device[k])
+                return out
+
+            node.meta["orig_target"] = node.target
+            node.target = new_func
+
+    model.recompile()
+    model.graph.lint()
+
+    ## All keys that have been deal through `call_function` are on CPU by default, and moved when needed
+    all_model_tensors = [name for name, _ in model.state_dict().items()]
+    for module_name in device_map.keys():
+        if module_name == "":
+            all_model_tensors.clear()
+            break
+        else:
+            all_model_tensors = [
+                name
+                for name in all_model_tensors
+                if not name == module_name and not name.startswith(module_name + ".")
+            ]
+    for tensor in all_model_tensors:
+        cpu_index = devices.index("cpu")
+        device_map[tensor] = devices[cpu_index]
+    return device_map
+
+
+def remove_hooks(model):
+    for module in model.modules():
+        if hasattr(module, "_hf_hook"):
+            del module.allocate_params
+            del module.offload_params
+    remove_hook_from_module(model, recurse=True)
+    model.cpu()
+    if hasattr(model, "graph"):
+        for node in model.graph.nodes:
+            if node.op == "call_function":
+                if "orig_target" in node.meta:
+                    node.target = node.meta["orig_target"]
+                    del node.meta["orig_target"]
+        model.recompile()
+        model.graph.lint()
+
+
+def update_internal_dict(module):
+    prefix = module._hf_hook.weights_map.prefix
+    for key in module.state_dict().keys():
+        module._hf_hook.weights_map.dataset.state_dict[prefix + key] = recurse_getattr(module, key + ".data")
+
+
+def offload_model(model: torch.nn.Module) -> torch.nn.Module:
+    """
+    Wraps accelerate's infer_auto_device_map and dispatch_model.
+
+    This functions if compatible both with classic nn.Modules, and with torch.fx.GraphModule.
+    """
+
+    # FX vs non-FX model need different offloading
+    config._FULL_STATE_DICT = True
+    cuda_device_map = {i: torch.cuda.mem_get_info(i)[0] * 0.7 for i in range(torch.cuda.device_count())}
+    cpu_device_map = {"cpu": virtual_memory().available * 0.7}
+    memory_map = {**cpu_device_map, **cuda_device_map}
+
+    if isinstance(model, torch.fx.GraphModule):
+        device_map = infer_fx_auto_device_map(model, memory_map)
+        device_map = offload_call_function(model, memory_map, device_map)
+    else:
+        device_map = infer_auto_device_map(model, memory_map, no_split_module_classes=model._no_split_modules)
+
+    model = dispatch_model(model, device_map)
+
+    # Fixes an asymetric behavior in Accelerate where hooks are not attached at all when a single device is used.
+    # TODO: Fix directly in accelerate.
+    if len(set(device_map.values())) == 1:
+        model = align_input(model, device_map)
+
+    config._FULL_STATE_DICT = False
+    if "disk" in model.hf_device_map.values():
+        raise ValueError("Disk offload is not supported with quantization.")
+
+    # We attach these functions to the hooked modules for convenience when modifying parameters during PTQ (e.g. SmoothQuant).
+    # Attaching these functions allows use to fix a bug in accelerate with offloading to RAM/disk where even though a submodule parameter is updated, it is actually not updated in the AlignDevicesHook `weights_map` and thus
+    # the update is ignored elsewhere.
+    # TODO: Fix this bug directly in accelerate. https://github.com/huggingface/accelerate/pull/2214 would fix the bug for RAM offliading.
+    def allocate_params(module, device="cpu"):
+        """
+        This function calls the pre_forward function of the _hf_hook, making sure parameters are on
+        the selected device, rather than on the meta device.
+        """
+        if module._hf_hook.offload is False:
+            return
+        module._hf_hook.pre_forward(module)
+        # When quantizing and retrieving parameters (e.g., during GPTQ), we want to recurse through
+        # all the submodules
+        for m in module.modules():
+            if hasattr(m, "_hf_hook"):
+                m._hf_hook.pre_forward(m)
+
+    def offload_params(module):
+        """
+        This functions moves the parameters back to the meta device, after making sure to update the
+        internal state dict with the most recent values.
+        """
+        if module._hf_hook.offload is False:
+            return
+        update_internal_dict(module)
+        module._hf_hook.post_forward(module, torch.tensor([]))
+        for m in module.modules():
+            if hasattr(m, "_hf_hook"):
+                m._hf_hook.post_forward(m, torch.tensor([]))
+
+    for module in model.modules():
+        if hasattr(module, "_hf_hook"):
+            module.allocate_params = allocate_params
+            module.offload_params = offload_params
+
+    return model

--- a/optimum/amd/brevitas/configuration.py
+++ b/optimum/amd/brevitas/configuration.py
@@ -1,0 +1,99 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+# Licensed under the MIT License.
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+
+@dataclass
+class BrevitasQuantizationConfig:
+    """
+    QuantizationConfig is the configuration class handling all the ONNX Runtime quantization parameters.
+
+    Args:
+        replace_mha_with_quantizable (`bool`, defaults to `False`):
+            TODO
+        seqlen (`int`, defaults to `2048`):
+            TODO: maybe move to a calibration config
+        nsamples (`int`, defaults to `128`):
+            TODO: maybe move to a calibration config
+        weights_bitwidth (`int`, defaults to `8`):
+            Bitwidth of the weights quantization. For example, with `weights_bitwidth=8`, each weight value is quantized on 8 bits.
+        activations_bitwidth (`int`, defaults to `8`):
+            Bitwidth of the activations quantization.
+        weights_param_method (`str`, defaults to `stats`):
+            TODO
+        weights_symmetric (`bool`, defaults to `True`):
+            Whether to use symmetric quantization on the weights.
+        scale_precision (`str`, defaults to `"float_scale"`):
+            Precise the constraints on the scale. Can either be `"float_scale"` (arbitrary scales), or `"power_of_two_scale"` (scales constrainted to be a power of 2).
+        weights_quant_granularity (`str`, defaults to `"per_tensor"`):
+            The granularity of the quantization of the weights. This parameter can either be:
+            - `"per_tensor"`: A single scale (and possibly zero-point) is used for one weight matrix.
+            - `"per_channel"`: Each column (outer dimension) of the weight matrix has its own scale (and possibly zero-point).
+            - `"per_group"`: Each column of the weight matrix may have several scales, grouped by `weight_group_size`.
+        weights_group_size (`Optional[int]`, defaults to `None`):
+            Group size to use for the weights in case `weights_quant_granularity="per_group"`. Defaults to `128` in this case, to `None` otherwise.
+        quantize_zero_point (`bool`, defaults to `True`):
+            TODO
+        activations_param_method (`List[str]`):
+            TODO
+        is_static (`bool`, defaults to `False`):
+            Whether to apply static quantization or dynamic quantization.
+        activations_symmetric (`bool`, defaults to `False`):
+            Whether to use symmetric quantization on the activations.
+        activations_quant_granularity (`str`, defaults to `"per_tensor"`):
+            The granularity of the quantization of the activations. This parameter can either be `"per_tensor"`, `"per_row"` or `"per_group"`. In case static quantization is used (`is_static=True`), only `"per_tensor"` may be used.
+        activations_group_size (`int`, defaults to `None`):
+            Group size to use for the activations in case `activations_quant_granularity="per_group"`. Defaults to `64` in this case, to `None` otherwise.
+        activations_equalization (`Optional[str]`, defaults to `"fx"`):
+            Whether to apply apply activation equalization (SmoothQuant). Possible options are:
+            - `None`: No activation equalization.
+            - `"fx"`: TODO
+            - `"layerwise"`: TODO
+        apply_weight_equalization (`bool`, defaults to `False`):
+            TODO
+        apply_gptq (`bool`, defaults to `False`):
+            Whether to apply GPTQ algorithm for quantizing the weights.
+        gptq_act_oder (`Optional[bool]`, defaults to `None`):
+            Whether to use activations reordering (act-order, also known as desc-act) when `apply_gptq=True`. If `apply_gptq=True`, defaults to `False`.
+    """
+
+    replace_mha_with_quantizable: bool = False
+    seqlen: int = 2048
+    nsamples: int = 128
+    weights_bitwidth: int = 8
+    activations_bitwidth: int = 8
+    weights_param_method: Literal["stats", "mse"] = "stats"
+    weights_symmetric: bool = True
+    scale_precision: Literal["float_scale", "power_of_two_scale"] = "float_scale"
+    weights_quant_granularity: Literal["per_tensor", "per_channel", "per_group"] = "per_tensor"
+    weights_group_size: Optional[int] = None
+    quantize_zero_point: bool = True
+    activations_param_method: Literal["stats", "mse"] = "stats"
+    is_static: bool = False
+    activations_symmetric: bool = False
+    activations_quant_granularity: Literal["per_tensor", "per_row", "per_group"] = "per_tensor"
+    activations_group_size: Optional[int] = None
+    activations_equalization: Literal[None, "layerwise", "fx"] = "fx"
+    apply_weight_equalization: bool = False
+    apply_gptq: bool = False
+    gptq_act_oder: Optional[bool] = None
+
+    def __post_init__(self):
+        if self.activations_quant_granularity == "per_group" and self.activations_group_size is None:
+            self.activations_group_size = 64
+
+        if self.weights_quant_granularity == "per_group" and self.weights_group_size is None:
+            self.weights_group_size = 128
+
+        if self.apply_gptq and self.gptq_act_oder is None:
+            self.gptq_act_oder = False
+
+        if self.is_static and self.activations_quant_granularity != "per_tensor":
+            raise ValueError(
+                f'Static quantization with activations_quant_granularity="{self.activations_quant_granularity}" is not supported. The quantization granularity must be activations_quant_granularity="per_tensor" when using static quantization.'
+            )
+
+        if self.activations_quant_granularity == "per_row" and not self.replace_mha_with_quantizable:
+            raise ValueError("Per-row activations quantization requires setting replace_mha_with_quantizable to True.")

--- a/optimum/amd/brevitas/data_utils.py
+++ b/optimum/amd/brevitas/data_utils.py
@@ -1,0 +1,122 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+# Licensed under the MIT License.
+
+import random
+from typing import Any, Dict, List
+
+import numpy as np
+import torch
+import torch.nn as nn
+from datasets import load_dataset
+from tqdm import tqdm
+
+
+@torch.no_grad()
+def model_eval_accelerate(model, data: List[Dict], seqlen: int):
+    encodings = {"input_ids": torch.empty((0,), dtype=torch.int64)}
+
+    # TODO: It is bad practice to compute perplexity like that (mixing up sequences in a single long sequence). The way evaluate handles it is cleaner: https://github.com/huggingface/evaluate/blob/8dfe05784099fb9af55b8e77793205a3b7c86465/metrics/perplexity/perplexity.py#L140
+    for batch in data:
+        encodings["input_ids"] = torch.cat((encodings["input_ids"], batch["input_ids"].squeeze(0)), dim=0)
+
+    encodings["input_ids"] = encodings["input_ids"].unsqueeze(0)
+
+    nsamples = encodings["input_ids"].numel() // seqlen
+    use_cache = model.config.use_cache
+    model.config.use_cache = False
+    with torch.no_grad():
+        nlls = []
+        for i in tqdm(range(nsamples)):
+            batch = encodings["input_ids"][:, (i * seqlen) : ((i + 1) * seqlen)].cuda()
+            attention_mask = torch.ones_like(batch)
+            lm_logits = model(input_ids=batch, attention_mask=attention_mask)["logits"]
+            shift_logits = lm_logits[:, :-1, :].contiguous()
+            shift_labels = (encodings["input_ids"][:, (i * seqlen) : ((i + 1) * seqlen)][:, 1:]).cuda()
+            loss_fct = nn.CrossEntropyLoss()
+            loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
+            neg_log_likelihood = loss.float() * seqlen
+            nlls.append(neg_log_likelihood)
+        ppl = torch.exp(torch.stack(nlls).sum() / (nsamples * seqlen))
+    model.config.use_cache = use_cache
+    return ppl
+
+
+def get_wikitext2(tokenizer: Any, seqlen: int, nsamples: int, split: str = "train"):
+    if split == "train":
+        data = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+    elif split == "validation":
+        data = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
+    # length of 288059 should be enough
+    text = "".join([" \n" if s == "" else s for s in data["text"][:1000]])
+
+    enc = tokenizer(text, return_tensors="pt")
+    dataset = []
+    for _ in range(nsamples):
+        i = random.randint(0, enc.input_ids.shape[1] - seqlen - 1)
+        j = i + seqlen
+        inp = enc.input_ids[:, i:j]
+        attention_mask = torch.ones_like(inp)
+        dataset.append({"input_ids": inp, "attention_mask": attention_mask})
+    return dataset
+
+
+def get_c4(tokenizer: Any, seqlen: int, nsamples: int, split: str = "train"):
+    if split == "train":
+        data = load_dataset("allenai/c4", split="train", data_files={"train": "en/c4-train.00000-of-01024.json.gz"})
+    elif split == "validation":
+        data = load_dataset(
+            "allenai/c4",
+            split="validation",
+            data_files={"validation": "en/c4-validation.00000-of-00008.json.gz"},
+        )
+    dataset = []
+    for _ in range(nsamples):
+        while True:
+            i = random.randint(0, len(data) - 1)
+            enc = tokenizer(data[i]["text"], return_tensors="pt")
+            if enc.input_ids.shape[1] >= seqlen:
+                break
+        i = random.randint(0, enc.input_ids.shape[1] - seqlen - 1)
+        j = i + seqlen
+        inp = enc.input_ids[:, i:j]
+        attention_mask = torch.ones_like(inp)
+        dataset.append({"input_ids": inp, "attention_mask": attention_mask})
+
+    return dataset
+
+
+def get_dataset(
+    dataset_name: str, tokenizer: Any, nsamples: int = 128, seqlen: int = 2048, seed: int = 0, split: str = "train"
+):
+    """
+    Get the dataset from the original paper of GPTQ
+
+    Args:
+        dataset_name (`str`):
+            Dataset name. Available options are `['wikitext2', 'c4']`.
+        tokenizer (`Any`):
+            Tokenizer of the model
+        nsamples (`int`, defaults to `128`):
+            Number of samples
+        seqlen (`int`, defaults to `2048`):
+            The sequence length of the model
+        seed (`int`, defaults to `0`):
+            Seed
+        split (`str`, defaults to `train`):
+            Split of the dataset. Can be either "train" or "validation"
+    Returns:
+        `List[Dict[str,torch.LongTensor]]`: The tokenized dataset.
+    """
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.random.manual_seed(seed)
+    get_dataset_map = {
+        "wikitext2": get_wikitext2,
+        "c4": get_c4,
+    }
+    if split not in ["train", "validation"]:
+        raise ValueError(f"The split need to be 'train' or 'validation' but found {split}")
+    if dataset_name not in get_dataset_map:
+        raise ValueError(f"Expected a value in {list(get_dataset_map.keys())} but found {dataset_name}")
+    get_dataset_fn = get_dataset_map[dataset_name]
+    return get_dataset_fn(tokenizer=tokenizer, nsamples=nsamples, seqlen=seqlen, split=split)

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -1,0 +1,196 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+# Licensed under the MIT License.
+
+import inspect
+import logging
+from typing import Dict, List, Optional, Union
+
+import torch
+from brevitas_examples.common.generative.quantize import quantize_model
+from brevitas_examples.llm.llm_quant.calibrate import apply_calibration
+
+# TODO: rather use Optimum/GPTQ data handlers.
+from brevitas_examples.llm.llm_quant.data import get_c4, get_wikitext2
+from brevitas_examples.llm.llm_quant.equalize import apply_act_equalization, apply_weight_equalization
+from brevitas_examples.llm.llm_quant.gptq import apply_gptq
+from brevitas_examples.llm.llm_quant.prepare_for_quantize import replace_mha_with_quantizable_layers
+
+from optimum.exporters import TasksManager
+from optimum.quantization_base import OptimumQuantizer
+from transformers.utils.fx import symbolic_trace
+
+from .configuration import BrevitasQuantizationConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+class BrevitasQuantizer(OptimumQuantizer):
+    """
+    Handles the Runtime quantization process for models shared on huggingface.co/models.
+    """
+
+    def __init__(self, model: torch.nn.Module):
+        super().__init__()
+        self.model = model
+        self.config = self.model.config
+
+    def validate_quant_config(self, quantization_config: BrevitasQuantizationConfig):
+        dtype = next(iter(self.model.parameters()))
+        if dtype == torch.bfloat16 and quantization_config.replace_mha_with_quantizable:
+            raise RuntimeError("Scaled_dot_product does not support bfloat16 and cuda")
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path: str,
+        subfolder: str = "",
+        revision: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+        trust_remote_code: bool = False,
+        force_download: bool = False,
+        local_files_only: bool = False,
+        use_auth_token: Optional[Union[bool, str]] = None,
+    ):
+        """
+        TODO: doc
+        """
+        task = TasksManager.infer_task_from_model(model_name_or_path)
+
+        model = TasksManager.get_model_from_task(
+            task,
+            model_name_or_path,
+            subfolder=subfolder,
+            revision=revision,
+            cache_dir=cache_dir,
+            use_auth_token=use_auth_token,
+            local_files_only=local_files_only,
+            force_download=force_download,
+            trust_remote_code=trust_remote_code,
+        )
+
+        return cls(model)
+
+    def quantize(
+        self, quantization_config: BrevitasQuantizationConfig, calibration_dataloader: Optional[List[Dict]] = None
+    ) -> torch.nn.Module:
+        """
+        TODO: doc
+        """
+        self.validate_quant_config(quantization_config)
+
+        requires_data = (
+            quantization_config.activations_equalization
+            or quantization_config.apply_gptq
+            or quantization_config.is_static
+        )
+        if calibration_dataloader is None and requires_data:
+            raise ValueError(
+                f"No calibration_dataloader was passed, but a calibration dataset is required with the quantization configuration activations_equalization={quantization_config.activations_equalization}, apply_gptq={quantization_config.apply_gptq}, is_static={quantization_config.is_static}."
+            )
+
+        if quantization_config.activations_equalization == "fx":
+            forward_signature = inspect.signature(self.model.forward).parameters
+            if all(
+                input_name in forward_signature for input_name in ["input_ids", "attention_mask", "past_key_values"]
+            ):
+                input_names = ["input_ids", "attention_mask", "past_key_values"]
+            else:
+                # TODO: implement
+                raise ValueError("Not implemented")
+
+            with torch.no_grad():
+                model = symbolic_trace(self.model, input_names)
+        else:
+            model = self.model
+
+        dtype = next(iter(model.parameters())).dtype
+
+        # Insert standard MHA layers when performing fx based weight/act equalization to avoid dealing
+        # with all the variability in HF implementations
+        if quantization_config.replace_mha_with_quantizable:
+            logger.info("Replace HF MHA with quantizable variants...")
+            model = replace_mha_with_quantizable_layers(model, dtype)
+            logger.info("Replacing done.")
+
+        # Because accelerate is not compatible with FX, we keep two versions of the Model
+        # one with FX-traced, the other one not.
+        # Since weights are shared across the two, we can apply weight/activation equalization
+        # by using one representation or the other based on needs.
+
+        if quantization_config.apply_weight_equalization:
+            logger.info("Applying weight equalization...")
+            apply_weight_equalization(model)
+            logger.info("Weight equalization applied.")
+
+        if quantization_config.activations_equalization is not None:
+            logger.info(
+                f"Applying Activation Equalization {quantization_config.activations_equalization} (SmoothQuant)..."
+            )
+            apply_act_equalization(
+                model, quantization_config.activations_equalization, calibration_dataloader, forward_call
+            )
+            logger.info("Activation equalization applied.")
+
+        # We do not quantize embedding and last fully connected layer
+        model = quantize_model(
+            model,
+            dtype=dtype,
+            weight_quant_format="int",
+            weight_quant_type="sym" if quantization_config.weights_symmetric else "asym",
+            weight_bit_width=quantization_config.weights_bitwidth,
+            weight_param_method=quantization_config.weights_param_method,
+            weight_scale_precision=quantization_config.scale_precision,
+            weight_quant_granularity=quantization_config.weights_quant_granularity,
+            weight_group_size=quantization_config.weights_group_size,
+            quantize_weight_zero_point=quantization_config.quantize_zero_point,
+            input_bit_width=quantization_config.activations_bitwidth,
+            input_quant_type="sym" if quantization_config.activations_symmetric else "asym",
+            input_quant_format="int",
+            input_param_method=quantization_config.activations_param_method,
+            input_scale_precision=quantization_config.scale_precision,
+            input_scale_type="static" if quantization_config.is_static else "dynamic",
+            input_quant_granularity=quantization_config.activations_quant_granularity,
+            input_group_size=quantization_config.activations_group_size,
+            quantize_input_zero_point=quantization_config.quantize_zero_point,
+            seqlen=quantization_config.seqlen,
+        )
+
+        # Perform a single inference pass to generate the correct state_dict
+        if quantization_config.apply_gptq or quantization_config.is_static:
+            with torch.no_grad():
+                model(**calibration_dataloader[0])
+
+        if quantization_config.apply_gptq:
+            logger.info("Applying gptq...")
+            apply_gptq(model, calibration_dataloader, forward_call)
+            logger.info("GPTQ applied.")
+
+        if quantization_config.activations_bitwidth is not None and quantization_config.is_static:
+            logger.info("Applying activation calibration...")
+            apply_calibration(model, calibration_dataloader, forward_call)
+            logger.info("Activation calibration applied.")
+
+        return model
+
+    # TODO: move out of here
+    def get_calibration_dataloader(
+        self,
+        tokenizer,
+        dataset_name="c4",
+        num_samples: int = 100,
+        seqlen: int = 2048,
+        seed: int = 0,
+    ):
+        if dataset_name == "c4":
+            calibration_dataloader = get_c4(nsamples=num_samples, seed=seed, tokenizer=tokenizer, seqlen=seqlen)
+        elif dataset_name == "wikitext2":
+            calibration_dataloader = get_wikitext2(
+                nsamples=num_samples, seqlen=seqlen, seed=seed, tokenizer=tokenizer, type=""
+            )
+        elif dataset_name == "wikitext2-raw":
+            calibration_dataloader = get_wikitext2(
+                nsamples=num_samples, seqlen=seqlen, seed=seed, tokenizer=tokenizer, type="raw"
+            )
+
+        return calibration_dataloader


### PR DESCRIPTION
As per title.

Port & adapt part of the code of https://github.com/Xilinx/brevitas/tree/optimum in optimum-amd.

Left to do:
- [ ] Fix FX compatibility, handling the KV cache in the dataset directly
- [ ] Fix tied weight logs during ONNX export weight dedup (e.g. `model.decoder.layers.0.self_attn.k_proj.weight_quant.tensor_quant.scaling_impl.parameter_list_stats.first_tracked_param.parameter`)
- [ ] Fix the perplexity computation to avoid grouping different sentences.
- [ ] Write tests
- [ ] Test exported models on Ryzen AI (maybe for a later PR)
- [ ] Documentation & cleaning remainings todos