### PR TITLE
Fix: Force unsigned activations when dynamic quantization is used

### DIFF
--- a/examples/quantization/brevitas/quantize_opt.py
+++ b/examples/quantization/brevitas/quantize_opt.py
@@ -65,7 +65,7 @@ qconfig = BrevitasQuantizationConfig(
     replace_mha_with_quantizable=args.replace_mha_with_quantizable,
     is_static=args.is_static,
     weights_symmetric=True,
-    activations_symmetric=True,
+    activations_symmetric=args.is_static, # ONNX export only supports unsigned for dynamic quantization
 )
 
 quantizer = BrevitasQuantizer.from_pretrained(args.model)


### PR DESCRIPTION
The combination of signed activations and dynamic quantization is [not supported by ORT](https://onnx.ai/onnx/operators/onnx__DynamicQuantizeLinear.html), so currently we don't not allow exporting to this.

Quote from above:
> Right now only uint8 is supported.