### PR TITLE
Update nightly CI

### DIFF
--- a/.github/workflows/test_ryzenai_nightly.yaml
+++ b/.github/workflows/test_ryzenai_nightly.yaml
@@ -12,7 +12,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  run_tests_prequantized_models:
+    strategy:
+      fail-fast: false
+    runs-on: [self-hosted, single-npu, amd-npu, ryzenai]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Create and start a virtual environment
+      run: |
+        conda create --prefix venv --clone C:\tools\Anaconda3\envs\ryzenai-1.0.1-ci
+        conda init
+        conda activate .\venv
+    - name: Install dependencies
+      run: |
+        conda activate .\venv
+        python -m pip install --upgrade pip
+        pip install .[tests]
+        pip install git+https://github.com/huggingface/optimum.git
+    - name: Test with Pytest
+      run: |
+        conda activate .\venv
+        $env:XLNX_VART_FIRMWARE="C:\RyzenAiSw\ryzen-ai-sw-1.0.1\voe-4.0-win_amd64\1x4.xclbin"
+        pytest -s -vvvvv -m "prequantized_model_test" --make-reports=tests_prequantized_models tests/ryzenai/test_modeling.py
+    - name: Failure short reports
+      if: ${{ failure() }}
+      continue-on-error: true
+      run: cat reports\tests_prequantized_models\failures_short.txt
+    - name: "Test suite reports artifacts"
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: run_tests_prequantized_models
+        path: .\reports\tests_prequantized\
+    - name: Cleanup
+      run: |
+        rm -r .\venv
+  run_tests_quantization:
     timeout-minutes: 1200 # 20 Hrs
     strategy:
       fail-fast: false
@@ -30,17 +65,22 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[tests]
         pip install git+https://github.com/huggingface/optimum.git
-    - name: Pre-quantized models test
-      run: |
-        conda activate .\venv
-        $env:XLNX_VART_FIRMWARE="C:\RyzenAiSw\ryzen-ai-sw-1.0.1\voe-4.0-win_amd64\1x4.xclbin"
-        pytest -s -vvvvv -m "prequantized_model_test" tests/ryzenai/test_modeling.py
-    - name: Quantization test
+    - name: Test with Pytest
       run: |
         conda activate .\venv
         huggingface-cli login --token ${{ secrets.HF_READ_TOKEN }}
         $env:XLNX_VART_FIRMWARE="C:\RyzenAiSw\ryzen-ai-sw-1.0.1\voe-4.0-win_amd64\1x4.xclbin"
-        $env:RUN_SLOW=1; pytest -s -vvvvv -m "quant_test" tests/ryzenai/test_quantization.py
+        $env:RUN_SLOW=1; pytest -s -vvvvv -m "quant_test" --make-reports=tests_quantization  tests/ryzenai/test_quantization.py
+    - name: Failure short reports
+      if: ${{ failure() }}
+      continue-on-error: true
+      run: cat reports\tests_quantization\failures_short.txt
+    - name: "Test suite reports artifacts"
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: run_tests_quantization
+        path: .\reports\tests_quantization\
     - name: Cleanup
       run: |
         rm -r .\venv

--- a/.github/workflows/test_ryzenai_nightly.yaml
+++ b/.github/workflows/test_ryzenai_nightly.yaml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: run_tests_prequantized_models
-        path: .\reports\tests_prequantized\
+        path: .\reports\tests_prequantized_models\
     - name: Cleanup
       run: |
         rm -r .\venv

--- a/.github/workflows/test_ryzenai_nightly.yaml
+++ b/.github/workflows/test_ryzenai_nightly.yaml
@@ -2,8 +2,6 @@ name: Ryzen Nightly - Test
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [ main ]
   schedule:
     - cron: 0 17 * * * # every day at 5pm UTC
 

--- a/.github/workflows/test_ryzenai_nightly.yaml
+++ b/.github/workflows/test_ryzenai_nightly.yaml
@@ -2,6 +2,8 @@ name: Ryzen Nightly - Test
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [ main ]
   schedule:
     - cron: 0 17 * * * # every day at 5pm UTC
 
@@ -11,6 +13,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 1200 # 20 Hrs
     strategy:
       fail-fast: false
     runs-on: [self-hosted, single-npu, amd-npu, ryzenai]
@@ -27,12 +30,17 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[tests]
         pip install git+https://github.com/huggingface/optimum.git
-    - name: Test with Pytest
+    - name: Pre-quantized models test
+      run: |
+        conda activate .\venv
+        $env:XLNX_VART_FIRMWARE="C:\RyzenAiSw\ryzen-ai-sw-1.0.1\voe-4.0-win_amd64\1x4.xclbin"
+        pytest -s -vvvvv -m "prequantized_model_test" tests/ryzenai/test_modeling.py
+    - name: Quantization test
       run: |
         conda activate .\venv
         huggingface-cli login --token ${{ secrets.HF_READ_TOKEN }}
         $env:XLNX_VART_FIRMWARE="C:\RyzenAiSw\ryzen-ai-sw-1.0.1\voe-4.0-win_amd64\1x4.xclbin"
-        $env:RUN_SLOW=1; pytest -s -vvvvv -m "quant_test or prequantized_model_test" tests/ryzenai/
+        $env:RUN_SLOW=1; pytest -s -vvvvv -m "quant_test" tests/ryzenai/test_quantization.py
     - name: Cleanup
       run: |
         rm -r .\venv

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
-import pytest
-
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+# Licensed under the MIT License.
 
 def pytest_addoption(parser):
     from transformers.testing_utils import pytest_addoption_shared

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 # Copyright 2023 The HuggingFace Team. All rights reserved.
 # Licensed under the MIT License.
 
+
 def pytest_addoption(parser):
     from transformers.testing_utils import pytest_addoption_shared
 

--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,5 @@ def pytest_terminal_summary(terminalreporter):
     from transformers.testing_utils import pytest_terminal_summary_main
 
     make_reports = terminalreporter.config.getoption("--make-reports")
-    # from pdb import set_trace; set_trace()
     if make_reports:
         pytest_terminal_summary_main(terminalreporter, id=make_reports)

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    from transformers.testing_utils import pytest_addoption_shared
+
+    pytest_addoption_shared(parser)
+
+
+def pytest_terminal_summary(terminalreporter):
+    from transformers.testing_utils import pytest_terminal_summary_main
+
+    make_reports = terminalreporter.config.getoption("--make-reports")
+    # from pdb import set_trace; set_trace()
+    if make_reports:
+        pytest_terminal_summary_main(terminalreporter, id=make_reports)

--- a/tests/ryzenai/test_modeling.py
+++ b/tests/ryzenai/test_modeling.py
@@ -76,7 +76,7 @@ class RyzenAIModelIntegrationTest(unittest.TestCase):
 class RyzenAIModelForImageClassificationIntegrationTest(unittest.TestCase):
     @parameterized.expand(RYZEN_PREQUANTIZED_MODEL_IMAGE_CLASSIFICATION)
     @pytest.mark.prequantized_model_test
-    def runTest(self, model_id):
+    def test_model(self, model_id):
         set_seed(SEED)
 
         all_files = huggingface_hub.list_repo_files(model_id, repo_type="model")


### PR DESCRIPTION
* Extend the default 6 hour timeout limit
* Add artifacts with summary of results (See: https://github.com/huggingface/optimum-amd/actions/runs/7853091792)