### PR TITLE
Fix offload

### DIFF
--- a/optimum/amd/brevitas/accelerate_utils.py
+++ b/optimum/amd/brevitas/accelerate_utils.py
@@ -422,10 +422,7 @@ def offload_model(model: torch.nn.Module) -> torch.nn.Module:
             if hasattr(m, "_hf_hook"):
                 # If a module has already been offloaded (because its forward pass was called),
                 # this will raise TypeError because of tied_pointers_to_remove is None
-                try:
-                    m._hf_hook.post_forward(m, torch.tensor([]))
-                except TypeError as e:
-                    pass
+                m._hf_hook.post_forward(m, torch.tensor([]))
 
     for module in model.modules():
         if hasattr(module, "_hf_hook"):

--- a/optimum/amd/brevitas/accelerate_utils.py
+++ b/optimum/amd/brevitas/accelerate_utils.py
@@ -420,8 +420,6 @@ def offload_model(model: torch.nn.Module) -> torch.nn.Module:
         update_internal_dict(module)
         for m in module.modules():
             if hasattr(m, "_hf_hook"):
-                # If a module has already been offloaded (because its forward pass was called),
-                # this will raise TypeError because of tied_pointers_to_remove is None
                 m._hf_hook.post_forward(m, torch.tensor([]))
 
     for module in model.modules():

--- a/optimum/amd/brevitas/accelerate_utils.py
+++ b/optimum/amd/brevitas/accelerate_utils.py
@@ -371,6 +371,7 @@ def offload_model(model: torch.nn.Module) -> torch.nn.Module:
 
     # FX vs non-FX model need different offloading
     config._FULL_STATE_DICT = True
+    torch.cuda.empty_cache()
     cuda_device_map = {i: torch.cuda.mem_get_info(i)[0] * 0.7 for i in range(torch.cuda.device_count())}
     cpu_device_map = {"cpu": virtual_memory().available * 0.7}
     memory_map = {**cpu_device_map, **cuda_device_map}

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -106,7 +106,6 @@ class BrevitasQuantizer(OptimumQuantizer):
                 In case the quantization involves a calibration phase, this argument needs to be specified as a list of inputs to the model.
                 Example: `calibration_dataset = [{"input_ids": torch.tensor([[1, 2, 3, 4]])}, {"input_ids": torch.tensor([[6, 7, 3, 4]])}]` which is a dataset for a model taking `input_ids` as an argument, and which has two samples.
         """
-        self.validate_quant_config(quantization_config)
 
         requires_data = (
             quantization_config.activations_equalization

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -106,6 +106,7 @@ class BrevitasQuantizer(OptimumQuantizer):
                 In case the quantization involves a calibration phase, this argument needs to be specified as a list of inputs to the model.
                 Example: `calibration_dataset = [{"input_ids": torch.tensor([[1, 2, 3, 4]])}, {"input_ids": torch.tensor([[6, 7, 3, 4]])}]` which is a dataset for a model taking `input_ids` as an argument, and which has two samples.
         """
+        self.validate_quant_config(quantization_config)
 
         requires_data = (
             quantization_config.activations_equalization


### PR DESCRIPTION
Bit of a workaround for the fact that we might call nested modules independently, which would trigger pre and post forward.

When manually calling post_forward, we need to check if a device is on meta, or if the post_forward fails because tied_pointers_to_remove is None.

We need to call `torch.cuda.empty_cache()` before `torch.cuda.mem_get_info()` to get accurate values.