### PR TITLE
Feat (brevitas/offload): Improve interoperation with accelerate

### DIFF
--- a/examples/quantization/brevitas/README.md
+++ b/examples/quantization/brevitas/README.md
@@ -11,7 +11,7 @@ The example shows an example on how to quantize a decoder-class LLM model throug
 ## Prerequisites
 
 The examples were tested using:
-- `brevitas>=0.10.1`
+- `brevitas>=0.10.2`
 - `torch>=2.1.2`
 - `transformers` installed from main (`pip install git+https://github.com/huggingface/transformers.git@4b236aed7618d90546cd2e8797dab5b4a24c5dce`)
 - `optimum>=1.17.0`

--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -134,7 +134,7 @@ print("Exporting the model to ONNX...")
 quantized_model = quantized_model.to("cpu")
 
 # Export to ONNX through optimum.exporters.
-with torch.no_grad(), brevitas_proxy_export_mode(model, export_manager=StdQCDQONNXManager):
+with torch.no_grad(), brevitas_proxy_export_mode(quantized_model, export_manager=StdQCDQONNXManager):
     onnx_export_from_model(
         model,
         "llm_quantized_onnx",

--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -54,9 +54,14 @@ args = parser.parse_args()
 
 tokenizer = AutoTokenizer.from_pretrained(args.model)
 
-# Prepare the quantizer, specifying its configuration and loading the model.
+# Specify how much of each device should set aside for accelerate's offload functions
+# The absolute margin is in bytes & the relative margin is a ratio
+# The margins are the portions of the device which should be reserved for other functions
+# (not accelerate)
 gpu_device_map = calc_gpu_device_map(absolute_mem_margin=2.0*1e9, relative_mem_margin=0.3)
 cpu_device_map = calc_cpu_device_map(absolute_mem_margin=2.0*1e9, relative_mem_margin=0.3)
+
+# Prepare the quantizer, specifying its configuration and loading the model.
 qconfig = BrevitasQuantizationConfig(
     apply_gptq=args.apply_gptq,
     apply_weight_equalization=args.apply_weight_equalization,

--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -83,7 +83,7 @@ qconfig = BrevitasQuantizationConfig(
 )
 
 quantizer = BrevitasQuantizer.from_pretrained(
-    args.model, device_map=args.device, # torch_dtype="auto" # fails for some reason with quantization enabled
+    args.model, device_map=args.device
 )
 
 # Load the data for calibration and evaluation.

--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -132,12 +132,6 @@ print(f"Perplexity (quantized model): {perplexity}")
 
 print("Exporting the model to ONNX...")
 model = model.to("cpu")
-for name, param in model.named_parameters():
-    if param.dtype in [torch.float16, torch.bfloat16]:
-        recurse_setattr(model, name, torch.nn.Parameter(param.to(torch.float32)))
-for name, param in model.named_buffers():
-    if param.dtype in [torch.float16, torch.bfloat16]:
-        recurse_setattr(model, name, torch.nn.Parameter(param.to(torch.float32)))
 
 # Export to ONNX through optimum.exporters.
 with torch.no_grad(), brevitas_proxy_export_mode(model, export_manager=StdQCDQONNXManager):

--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -114,7 +114,7 @@ model = quantizer.model
 
 # Evaluation of the non-quantized model.
 if use_accelerate:
-    offload_model = offload_model(model, qconfig.gpu_device_map, qconfig.cpu_device_map)
+    model = offload_model(model, qconfig.gpu_device_map, qconfig.cpu_device_map)
 perplexity = compute_perplexity(model, validation_dataset, context_length=args.seqlen // 2, tokenizer=tokenizer)
 if use_accelerate:
     remove_hooks(model)
@@ -124,7 +124,7 @@ quantized_model = quantizer.quantize(qconfig, calibration_dataset)
 
 # Evaluation of the quantized model.
 if use_accelerate:
-    offload_model = offload_model(quantized_model, qconfig.gpu_device_map, qconfig.cpu_device_map)
+    quantized_model = offload_model(quantized_model, qconfig.gpu_device_map, qconfig.cpu_device_map)
 perplexity = compute_perplexity(quantized_model, validation_dataset, context_length=args.seqlen // 2, tokenizer=tokenizer)
 if use_accelerate:
     remove_hooks(model)

--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -131,7 +131,7 @@ if use_accelerate:
 print(f"Perplexity (quantized model): {perplexity}")
 
 print("Exporting the model to ONNX...")
-model = model.to("cpu")
+quantized_model = quantized_model.to("cpu")
 
 # Export to ONNX through optimum.exporters.
 with torch.no_grad(), brevitas_proxy_export_mode(model, export_manager=StdQCDQONNXManager):

--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -67,7 +67,7 @@ tokenizer = AutoTokenizer.from_pretrained(args.model)
 # The absolute margin is in bytes & the relative margin is a ratio
 # The margins are the portions of the device which should be reserved for other functions
 # (not accelerate)
-use_accelerate = args.device != "auto"
+use_accelerate = args.device == "auto"
 gpu_device_map = calc_gpu_device_map(absolute_mem_margin=2.0*1e9, relative_mem_margin=0.3)
 cpu_device_map = calc_cpu_device_map(absolute_mem_margin=2.0*1e9, relative_mem_margin=0.3)
 

--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -116,21 +116,17 @@ model = quantizer.model
 if use_accelerate:
     model = offload_model(model, qconfig.gpu_device_map, qconfig.cpu_device_map)
 perplexity = compute_perplexity(model, validation_dataset, context_length=args.seqlen // 2, tokenizer=tokenizer)
-if use_accelerate:
-    remove_hooks(model)
 print(f"Perplexity (original model): {perplexity}")
 
 quantized_model = quantizer.quantize(qconfig, calibration_dataset)
 
 # Evaluation of the quantized model.
-if use_accelerate:
-    quantized_model = offload_model(quantized_model, qconfig.gpu_device_map, qconfig.cpu_device_map)
 perplexity = compute_perplexity(quantized_model, validation_dataset, context_length=args.seqlen // 2, tokenizer=tokenizer)
-if use_accelerate:
-    remove_hooks(quantized_model)
 print(f"Perplexity (quantized model): {perplexity}")
 
 print("Exporting the model to ONNX...")
+if use_accelerate:
+    remove_hooks(quantized_model)
 quantized_model = quantized_model.to("cpu")
 
 # Export to ONNX through optimum.exporters.

--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -127,7 +127,7 @@ if use_accelerate:
     quantized_model = offload_model(quantized_model, qconfig.gpu_device_map, qconfig.cpu_device_map)
 perplexity = compute_perplexity(quantized_model, validation_dataset, context_length=args.seqlen // 2, tokenizer=tokenizer)
 if use_accelerate:
-    remove_hooks(model)
+    remove_hooks(quantized_model)
 print(f"Perplexity (quantized model): {perplexity}")
 
 print("Exporting the model to ONNX...")

--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -67,6 +67,7 @@ tokenizer = AutoTokenizer.from_pretrained(args.model)
 # The absolute margin is in bytes & the relative margin is a ratio
 # The margins are the portions of the device which should be reserved for other functions
 # (not accelerate)
+use_accelerate = args.device != "auto"
 gpu_device_map = calc_gpu_device_map(absolute_mem_margin=2.0*1e9, relative_mem_margin=0.3)
 cpu_device_map = calc_cpu_device_map(absolute_mem_margin=2.0*1e9, relative_mem_margin=0.3)
 
@@ -95,7 +96,7 @@ calibration_dataset = get_dataset_for_model(
     nsamples=128,
     seqlen=args.seqlen,
     split="train",
-    device=args.device if args.device != "auto" else None,
+    device=args.device if not use_accelerate else None,
 )
 
 validation_dataset = get_dataset_for_model(
@@ -106,11 +107,10 @@ validation_dataset = get_dataset_for_model(
     nsamples=128,
     seqlen=args.seqlen,
     split="validation",
-    device=args.device if args.device != "auto" else None,
+    device=args.device if not use_accelerate else None,
 )
 
 model = quantizer.model
-use_accelerate = args.device != "auto"
 
 # Evaluation of the non-quantized model.
 if use_accelerate:

--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -136,7 +136,7 @@ quantized_model = quantized_model.to("cpu")
 # Export to ONNX through optimum.exporters.
 with torch.no_grad(), brevitas_proxy_export_mode(quantized_model, export_manager=StdQCDQONNXManager):
     onnx_export_from_model(
-        model,
+        quantized_model,
         "llm_quantized_onnx",
         task="text-generation-with-past",
         do_validation=False,

--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -49,6 +49,12 @@ parser.add_argument(
     default=128,
     help="Sequence length to use during calibration (default: %(default)s).",
 )
+parser.add_argument(
+    "--device",
+    type=str,
+    default="auto",
+    help="Device to run the example on (e.q., \"cpu\", \"cuda:0\", \"auto\"). \"auto\" will automatically select the device using HuggingFace Accelerate (default: %(default)s).",
+)
 
 args = parser.parse_args()
 

--- a/optimum/amd/brevitas/accelerate_utils.py
+++ b/optimum/amd/brevitas/accelerate_utils.py
@@ -364,7 +364,18 @@ def find_all_devices(data):
         return [(data, str(data.device))]
 
 
-def offload_model(model: torch.nn.Module) -> torch.nn.Module:
+def calc_gpu_device_map(absolute_mem_margin: float = 2*1e9, relative_mem_margin: float = 0.3) -> Dict[int, float]:
+    torch.cuda.empty_cache()
+    gpu_device_map = {i: (torch.cuda.mem_get_info(i)[0] - absolute_mem_margin) * (1.0 - relative_mem_margin) for i in range(torch.cuda.device_count())}
+    return gpu_device_map
+
+
+def calc_cpu_device_map(absolute_mem_margin: float = 0.0, relative_mem_margin: float = 0.3) -> Dict[str, float]:
+    cpu_device_map = {"cpu": (virtual_memory().available - absolute_mem_margin) * (1.0 - relative_mem_margin)}
+    return cpu_device_map
+
+
+def offload_model(model: torch.nn.Module, gpu_device_map: Optional[Dict[int, float]] = None, cpu_device_map: Optional[Dict[str, float]] = None) -> torch.nn.Module:
     """
     Wraps accelerate's infer_auto_device_map and dispatch_model.
 
@@ -373,10 +384,11 @@ def offload_model(model: torch.nn.Module) -> torch.nn.Module:
 
     # FX vs non-FX model need different offloading
     config._FULL_STATE_DICT = True
-    torch.cuda.empty_cache()
-    cuda_device_map = {i: torch.cuda.mem_get_info(i)[0] * 0.7 for i in range(torch.cuda.device_count())}
-    cpu_device_map = {"cpu": virtual_memory().available * 0.7}
-    memory_map = {**cpu_device_map, **cuda_device_map}
+    if gpu_device_map is None:
+        gpu_device_map = calc_gpu_device_map()
+    if cpu_device_map is None:
+        cpu_device_map = calc_cpu_device_map()
+    memory_map = {**cpu_device_map, **gpu_device_map}
 
     if isinstance(model, torch.fx.GraphModule):
         device_map = infer_fx_auto_device_map(model, memory_map)

--- a/optimum/amd/brevitas/accelerate_utils.py
+++ b/optimum/amd/brevitas/accelerate_utils.py
@@ -364,20 +364,6 @@ def find_all_devices(data):
         return [(data, str(data.device))]
 
 
-class accelerate_offload:
-    def __init__(self, model: torch.nn.Module, gpu_device_map: Optional[Dict[int, float]] = None, cpu_device_map: Optional[Dict[str, float]] = None):
-        self.model = model
-        self.gpu_device_map = gpu_device_map
-        self.cpu_device_map = cpu_device_map
-
-    def __enter__(self):
-        offload_model(self.model, self.gpu_device_map, self.cpu_device_map)
-        return self.model
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        remove_hooks(self.model)
-
-
 def calc_gpu_device_map(absolute_mem_margin: float = 2.0*1e9, relative_mem_margin: float = 0.3) -> Dict[int, float]:
     torch.cuda.empty_cache()
     gpu_device_map = {i: (torch.cuda.mem_get_info(i)[0] - absolute_mem_margin) * (1.0 - relative_mem_margin) for i in range(torch.cuda.device_count())}

--- a/optimum/amd/brevitas/accelerate_utils.py
+++ b/optimum/amd/brevitas/accelerate_utils.py
@@ -364,13 +364,27 @@ def find_all_devices(data):
         return [(data, str(data.device))]
 
 
-def calc_gpu_device_map(absolute_mem_margin: float = 2*1e9, relative_mem_margin: float = 0.3) -> Dict[int, float]:
+class accelerate_offload:
+    def __init__(self, model: torch.nn.Module, gpu_device_map: Optional[Dict[int, float]] = None, cpu_device_map: Optional[Dict[str, float]] = None):
+        self.model = model
+        self.gpu_device_map = gpu_device_map
+        self.cpu_device_map = cpu_device_map
+
+    def __enter__(self):
+        offload_model(self.model, self.gpu_device_map, self.cpu_device_map)
+        return self.model
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        remove_hooks(self.model)
+
+
+def calc_gpu_device_map(absolute_mem_margin: float = 2.0*1e9, relative_mem_margin: float = 0.3) -> Dict[int, float]:
     torch.cuda.empty_cache()
     gpu_device_map = {i: (torch.cuda.mem_get_info(i)[0] - absolute_mem_margin) * (1.0 - relative_mem_margin) for i in range(torch.cuda.device_count())}
     return gpu_device_map
 
 
-def calc_cpu_device_map(absolute_mem_margin: float = 0.0, relative_mem_margin: float = 0.3) -> Dict[str, float]:
+def calc_cpu_device_map(absolute_mem_margin: float = 2.0*1e9, relative_mem_margin: float = 0.3) -> Dict[str, float]:
     cpu_device_map = {"cpu": (virtual_memory().available - absolute_mem_margin) * (1.0 - relative_mem_margin)}
     return cpu_device_map
 

--- a/optimum/amd/brevitas/configuration.py
+++ b/optimum/amd/brevitas/configuration.py
@@ -59,7 +59,6 @@ class BrevitasQuantizationConfig:
             Whether to apply GPTQ algorithm for quantizing the weights.
         gptq_act_order (`Optional[bool]`, defaults to `None`):
             Whether to use activations reordering (act-order, also known as desc-act) when `apply_gptq=True`. If `apply_gptq=True`, defaults to `False`.
-        gpu_device_map (`Optional[bool[int, float]]`, defaults to `None`):
     """
 
     weights_bitwidth: int = 8

--- a/optimum/amd/brevitas/configuration.py
+++ b/optimum/amd/brevitas/configuration.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Literal, Optional, Dict
 
 
 @dataclass

--- a/optimum/amd/brevitas/configuration.py
+++ b/optimum/amd/brevitas/configuration.py
@@ -57,6 +57,7 @@ class BrevitasQuantizationConfig:
             Whether to apply GPTQ algorithm for quantizing the weights.
         gptq_act_oder (`Optional[bool]`, defaults to `None`):
             Whether to use activations reordering (act-order, also known as desc-act) when `apply_gptq=True`. If `apply_gptq=True`, defaults to `False`.
+        gpu_device_map (`Optional[bool[int, float]]`, defaults to `None`):
     """
 
     weights_bitwidth: int = 8
@@ -77,6 +78,8 @@ class BrevitasQuantizationConfig:
     apply_bias_correction: bool = False
     apply_gptq: bool = False
     gptq_act_oder: Optional[bool] = None
+    gpu_device_map: Optional[Dict[int, float]] = None
+    cpu_device_map: Optional[Dict[str, float]] = None
 
     def __post_init__(self):
         if self.activations_quant_granularity == "per_group" and self.activations_group_size is None:

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -342,8 +342,3 @@ def apply_bias_correction(model: torch.nn.Module, dataset: List[Dict]) -> None:
     with bias_correction_mode(model):
         for inps in tqdm(dataset):
             model(**inps)
-
-    # Recompile graph in case we've made any changes
-    if hasattr(model, "graph"):
-        model.recompile()
-        model.graph.lint()

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -158,11 +158,17 @@ class BrevitasQuantizer(OptimumQuantizer):
             apply_weight_equalization(model)
             logger.info("Weight equalization applied.")
 
+        if use_accelerate:
+            offload_context = accelerate_offload(model, quantization_config.gpu_device_map, quantization_config.cpu_device_map)
+        else:
+            offload_context = contextlib.nullcontext()
+
         if quantization_config.activations_equalization is not None:
             logger.info(
                 f"Applying Activation Equalization {quantization_config.activations_equalization} (SmoothQuant)..."
             )
-            apply_act_equalization(model, quantization_config.activations_equalization, calibration_dataset)
+            with offload_context:
+                apply_act_equalization(model, quantization_config.activations_equalization, calibration_dataset)
             logger.info("Activation equalization applied.")
 
         if use_accelerate:
@@ -230,8 +236,6 @@ class BrevitasQuantizer(OptimumQuantizer):
 
         if use_accelerate:
             offload_context = accelerate_offload(model, quantization_config.gpu_device_map, quantization_config.cpu_device_map)
-        else:
-            offload_context = contextlib.nullcontext()
 
         if quantization_config.apply_gptq:
             logger.info("Applying gptq...")

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -204,7 +204,7 @@ class BrevitasQuantizer(OptimumQuantizer):
         # Perform a single inference pass to generate the correct state_dict. This is necessary as Brevitas has some magic where
         # a first forward pass need to be called before quantizing a model:
         # https://github.com/Xilinx/brevitas/blob/84f42259ec869eb151af4cb8a8b23ad925f493db/src/brevitas/core/scaling/standalone.py#L205-L217
-        with torch.no_grad():
+        with torch.no_grad(), quantize_context:
             if calibration_dataset is not None:
                 model(**calibration_dataset[0])
             elif not isinstance(model, torch.fx.GraphModule):

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -165,8 +165,7 @@ class BrevitasQuantizer(OptimumQuantizer):
             logger.info(
                 f"Applying Activation Equalization {quantization_config.activations_equalization} (SmoothQuant)..."
             )
-            with offload_context:
-                apply_act_equalization(model, quantization_config.activations_equalization, calibration_dataset)
+            apply_act_equalization(model, quantization_config.activations_equalization, calibration_dataset)
             logger.info("Activation equalization applied.")
 
         if use_accelerate:
@@ -238,28 +237,25 @@ class BrevitasQuantizer(OptimumQuantizer):
 
         if quantization_config.apply_gptq:
             logger.info("Applying gptq...")
-            with offload_context:
-                apply_gptq(
-                    model,
-                    calibration_dataset,
-                    act_order=quantization_config.gptq_act_oder,
-                    group_of_parallel_layers=self.group_of_parallel_layers,
-                )
+            apply_gptq(
+                model,
+                calibration_dataset,
+                act_order=quantization_config.gptq_act_oder,
+                group_of_parallel_layers=self.group_of_parallel_layers,
+            )
             logger.info("GPTQ applied.")
 
         if quantization_config.activations_bitwidth is not None and quantization_config.is_static:
             logger.info("Applying activation calibration...")
-            with offload_context:
-                apply_calibration(model, calibration_dataset)
+            apply_calibration(model, calibration_dataset)
             logger.info("Activation calibration applied.")
 
         if quantization_config.apply_bias_correction:
             logger.info("Applying Bias Correction...")
-            with offload_context:
-                apply_bias_correction(
-                    model,
-                    calibration_dataset,
-                )
+            apply_bias_correction(
+                model,
+                calibration_dataset,
+            )
             logger.info("Bias Correction applied.")
 
         if use_accelerate:

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -158,6 +158,7 @@ class BrevitasQuantizer(OptimumQuantizer):
         model = quantize_model(
             model,
             dtype=dtype,
+            device=None,
             weight_quant_format="int",
             weight_quant_type="sym" if quantization_config.weights_symmetric else "asym",
             weight_bit_width=quantization_config.weights_bitwidth,

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -130,7 +130,7 @@ class BrevitasQuantizer(OptimumQuantizer):
                 f"No calibration_dataset was passed, but a calibration dataset is required with the quantization configuration activations_equalization={quantization_config.activations_equalization}, apply_gptq={quantization_config.apply_gptq}, is_static={quantization_config.is_static}."
             )
 
-        use_accelerate = hasattr(self.model, "hf_device_map")
+        use_accelerate = quantization_config.device == "auto"
         dtype = next(iter(self.model.parameters())).dtype
 
         if quantization_config.requires_fx_graph():

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -130,7 +130,7 @@ class BrevitasQuantizer(OptimumQuantizer):
                 f"No calibration_dataset was passed, but a calibration dataset is required with the quantization configuration activations_equalization={quantization_config.activations_equalization}, apply_gptq={quantization_config.apply_gptq}, is_static={quantization_config.is_static}."
             )
 
-        use_accelerate = quantization_config.device == "auto"
+        use_accelerate = hasattr(self.model, "hf_device_map")
         dtype = next(iter(self.model.parameters())).dtype
 
         if quantization_config.requires_fx_graph():


### PR DESCRIPTION
Various QoL improvements around how the example interoperates with accelerate. @fxmarty was working on similar functionality in #54. This should incorporate the good ideas in both approaches.
 - [x] Expose allocated device memory to the top level
 - [x] Update how accelerate is called for the quantized model
   - [x] Remove accelerate offload context manager
   - [x] Put in single call(s) to offload / remove hooks where necessary
 - [x] Allow user to run example without leveraging accelerate (CPU & GPU device targets)
 - [x] Remove extra code related to automated torch dtype optimization
- [ ] ~Remove accelerate as a **required** dependency~