### PR TITLE
Minimal fixes to Brevitas example

### DIFF
--- a/optimum/amd/brevitas/data_utils.py
+++ b/optimum/amd/brevitas/data_utils.py
@@ -108,7 +108,9 @@ def get_wikitext2(
         data = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
 
     if fuse_sequences:
-        tokenized_data = tokenizer("\n\n".join(data["text"]), return_tensors="pt")
+        data = data.shuffle(seed=seed)
+        # wikitext2 is too big.
+        tokenized_data = tokenizer("\n\n".join(data["text"])[:100000], return_tensors="pt")
 
         dataset = []
         for _ in range(nsamples):

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -101,6 +101,7 @@ class BrevitasQuantizer(OptimumQuantizer):
             trust_remote_code=trust_remote_code,
             device_map=device_map,
             device=device,
+            framework="pt",
             **model_kwargs,
         )
 


### PR DESCRIPTION
Remove an unnecessary log & avoid processing too long sequences with wikitext2.