### PR TITLE
Feat (accelerate): remove useless call to accelerate

### DIFF
--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -57,8 +57,6 @@ def main(args):
     model = quantizer.model
 
     # Evaluation of the non-quantized model.
-    if use_accelerate:
-        model = offload_model(model, qconfig.gpu_device_map, qconfig.cpu_device_map)
     perplexity = compute_perplexity(model, validation_dataset, context_length=args.seqlen // 2, tokenizer=tokenizer)
     return_val["float_perplexity"] = perplexity
     print(f"Perplexity (original model): {perplexity}")
@@ -75,7 +73,6 @@ def main(args):
     print("Exporting the model to ONNX...")
     if use_accelerate:
         remove_hooks(quantized_model)
-    quantized_model = quantized_model.to("cpu")
 
     # Export to ONNX through optimum.exporters.
     export_manager = StdQCDQONNXManager

--- a/optimum/amd/brevitas/accelerate_utils.py
+++ b/optimum/amd/brevitas/accelerate_utils.py
@@ -314,8 +314,10 @@ def offload_call_function(model: torch.fx.GraphModule, device_map: Dict):
 def remove_hooks(model: torch.nn.Module):
     for module in model.modules():
         if hasattr(module, "_hf_hook"):
-            del module.allocate_params
-            del module.offload_params
+            if hasattr(module, 'allocate_params'):
+                del module.allocate_params
+            if hasattr(module, 'offload_params'):
+                del module.offload_params
     remove_hook_from_module(model, recurse=True)
     model.cpu()
     if hasattr(model, "graph"):


### PR DESCRIPTION
We don't need to call accelerate in `quantize_llm` since the model will use device_map='auto' when accelerate is enabled.

We need to check if `allocate_params` and `offload_params` are present before trying to remove them.

We don't need to call `to.cpu()` since `remove_hooks` will do that by default.