### PR TITLE
Fix (brevitas/quantizer): Removed the initial forward call in the quantizer

### DIFF
--- a/examples/quantization/brevitas/README.md
+++ b/examples/quantization/brevitas/README.md
@@ -11,7 +11,7 @@ The example shows an example on how to quantize a decoder-class LLM model throug
 ## Prerequisites
 
 The examples were tested using:
-- `brevitas>=0.10.2`
+- `brevitas` installed from dev (`pip install git+https://github.com/Xilinx/brevitas.git@dev`)
 - `torch>=2.1.2`
 - `transformers` installed from main (`pip install git+https://github.com/huggingface/transformers.git@4b236aed7618d90546cd2e8797dab5b4a24c5dce`)
 - `optimum>=1.17.0`

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -201,39 +201,6 @@ class BrevitasQuantizer(OptimumQuantizer):
             quantize_input_zero_point=quantization_config.quantize_zero_point,
         )
 
-        # Perform a single inference pass to generate the correct state_dict. This is necessary as Brevitas has some magic where
-        # a first forward pass need to be called before quantizing a model:
-        # https://github.com/Xilinx/brevitas/blob/84f42259ec869eb151af4cb8a8b23ad925f493db/src/brevitas/core/scaling/standalone.py#L205-L217
-        with torch.no_grad():
-            if calibration_dataset is not None:
-                model(**calibration_dataset[0])
-            elif not isinstance(model, torch.fx.GraphModule):
-                model(input_ids=torch.tensor([[1]], dtype=torch.int64))
-            else:
-                device = torch.device(next(model.parameters()).device)
-                # TODO: clean that later.
-                config = AutoConfig.from_pretrained(self.model_name_or_path)
-
-                normalized_config_class = NormalizedConfigManager.get_normalized_config_class(config.model_type)
-                normalized_config = normalized_config_class(config)
-
-                num_heads = normalized_config.num_attention_heads
-                head_dim = normalized_config.hidden_size // num_heads
-                num_layers = normalized_config.num_layers
-
-                sample = {
-                    "input_ids": torch.tensor([[1]], dtype=torch.int64, device=device),
-                    "attention_mask": torch.tensor([[1]], dtype=torch.int64, device=device),
-                }
-                sample["past_key_values"] = tuple(
-                    (
-                        torch.zeros(1, num_heads, 0, head_dim, device=device),
-                        torch.zeros(1, num_heads, 0, head_dim, device=device),
-                    )
-                    for _ in range(num_layers)
-                )
-                model(**sample)
-
         if use_accelerate:
             model = offload_model(model, quantization_config.gpu_device_map, quantization_config.cpu_device_map)
 

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -15,8 +15,6 @@ from tqdm import tqdm
 
 from optimum.exporters import TasksManager
 from optimum.quantization_base import OptimumQuantizer
-from optimum.utils.normalized_config import NormalizedConfigManager
-from transformers import AutoConfig
 from transformers.utils.fx import symbolic_trace
 
 from .accelerate_utils import offload_model, remove_hooks


### PR DESCRIPTION
Thanks to [this fix](https://github.com/Xilinx/brevitas/pull/874), an initial forward pass of a Brevitas module is no longer required when using accelerate. Note, this PR superseeds #83.

~After merging, please pin you brevitas version to `506954cba84aea81f3ee740b4b36d56ce5489a88` until this commit lands in a Brevitas release.~ Stay pinned to `dev`.