### PR TITLE
Brevitas: avoid fusing sequences for quantization

### DIFF
--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -41,6 +41,7 @@ def main(args):
         seqlen=args.seqlen,
         split="train",
         device=args.device if not use_accelerate else None,
+        fuse_sequences=args.fuse_sequences,
     )
 
     validation_dataset = get_dataset_for_model(
@@ -52,6 +53,7 @@ def main(args):
         seqlen=args.seqlen,
         split="validation",
         device=args.device if not use_accelerate else None,
+        fuse_sequences=args.fuse_sequences,
     )
 
     model = quantizer.model
@@ -138,6 +140,12 @@ if __name__ == "__main__":
         type=int,
         default=128,
         help="Number of samples to use during calibration & validation (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--fuse-sequences",
+        action="store_true",
+        default=False,
+        help="Whether to merge the dataset sequences in case they are shorter than the requested number of samples per sequence. This is useful in case you would like to quantize or evaluate on long sequences (default: %(default)s).",
     )
     parser.add_argument(
         "--device",

--- a/optimum/amd/brevitas/data_utils.py
+++ b/optimum/amd/brevitas/data_utils.py
@@ -133,9 +133,12 @@ def get_wikitext2(
                 start_idx = random.randint(0, enc["input_ids"].shape[1] - seqlen)
                 end_idx = start_idx + seqlen - 1
                 attention_mask = torch.ones((1, seqlen), dtype=torch.int64)
-                dataset.append(
-                    {"input_ids": enc["input_ids"][:, start_idx : end_idx + 1], "attention_mask": attention_mask}
-                )
+                input_ids = enc["input_ids"][:, start_idx : end_idx + 1]
+
+                # Add BOS token.
+                input_ids[:, 0] = tokenizer.bos_token_id
+
+                dataset.append({"input_ids": input_ids, "attention_mask": attention_mask})
                 pbar.update(1)
 
     return dataset
@@ -181,9 +184,12 @@ def get_c4(
                 start_idx = random.randint(0, enc["input_ids"].shape[1] - seqlen)
                 end_idx = start_idx + seqlen - 1
                 attention_mask = torch.ones((1, seqlen), dtype=torch.int64)
-                dataset.append(
-                    {"input_ids": enc["input_ids"][:, start_idx : end_idx + 1], "attention_mask": attention_mask}
-                )
+                input_ids = enc["input_ids"][:, start_idx : end_idx + 1]
+
+                # Add BOS token.
+                input_ids[:, 0] = tokenizer.bos_token_id
+
+                dataset.append({"input_ids": input_ids, "attention_mask": attention_mask})
                 pbar.update(1)
 
     return dataset


### PR DESCRIPTION
As per title

With `CUDA_VISIBLE_DEVICES=0 python quantize_llm.py` go back to:
```
Perplexity (original model): 39.521244049072266
/home/fxmarty/anaconda3/envs/hf-inf/lib/python3.9/site-packages/torch/_tensor.py:1394: UserWarning: Named tensors and all their associated APIs are an experimental feature and subject to change. Please do not use them for anything important until they are released as stable. (Triggered internally at ../c10/core/TensorImpl.h:1908.)
  return super().rename(names)
Computing perplexity...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████| 128/128 [00:14<00:00,  8.98it/s]
Perplexity (quantized model): 41.81800079345703
```