### PR TITLE
Feat: remove last layer quantization

### DIFF
--- a/optimum/amd/brevitas/configuration.py
+++ b/optimum/amd/brevitas/configuration.py
@@ -81,6 +81,7 @@ class BrevitasQuantizationConfig:
     apply_gptq: bool = False
     gptq_act_order: Optional[bool] = None
     device: str = "auto"
+    exclude_last_layer: bool = True,
     gpu_device_map: Optional[Dict[int, float]] = None
     cpu_device_map: Optional[Dict[str, float]] = None
 

--- a/optimum/amd/brevitas/configuration.py
+++ b/optimum/amd/brevitas/configuration.py
@@ -59,8 +59,8 @@ class BrevitasQuantizationConfig:
             Whether to apply GPTQ algorithm for quantizing the weights.
         gptq_act_order (`Optional[bool]`, defaults to `None`):
             Whether to use activations reordering (act-order, also known as desc-act) when `apply_gptq=True`. If `apply_gptq=True`, defaults to `False`.
-        layers_to_exclude:(`Optional[List]`, defaults to None):
-            Specify the names of the layers that should not be quantized. This should only be the last part of the layer name. If the same name is repated across multiple layers, they will all be excluded.
+        layers_to_exclude (`Optional[List]`, defaults to `None`):
+            Specify the names of the layers that should not be quantized. This should only be the last part of the layer name. If the same name is repeated across multiple layers, they will all be excluded.
             If left to None, the last linear layer is automatically identified and excluded.
     """
 

--- a/optimum/amd/brevitas/configuration.py
+++ b/optimum/amd/brevitas/configuration.py
@@ -83,7 +83,7 @@ class BrevitasQuantizationConfig:
     apply_gptq: bool = False
     gptq_act_order: Optional[bool] = None
     device: str = "auto"
-    exclude_last_layer: bool = (True,)
+    exclude_last_layer: bool = True
     gpu_device_map: Optional[Dict[int, float]] = None
     cpu_device_map: Optional[Dict[str, float]] = None
 

--- a/optimum/amd/brevitas/configuration.py
+++ b/optimum/amd/brevitas/configuration.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 from dataclasses import dataclass
-from typing import Dict, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 
 @dataclass
@@ -59,8 +59,9 @@ class BrevitasQuantizationConfig:
             Whether to apply GPTQ algorithm for quantizing the weights.
         gptq_act_order (`Optional[bool]`, defaults to `None`):
             Whether to use activations reordering (act-order, also known as desc-act) when `apply_gptq=True`. If `apply_gptq=True`, defaults to `False`.
-        exclude_last_layer ('bool', defaults to True):
-            Whether to exclude the last layer from quantization and leave it in its original precision.
+        layers_to_exclude:(`Optional[List]`, defaults to None):
+            Specify the names of the layers that should not be quantized. This should only be the last part of the layer name. If the same name is repated across multiple layers, they will all be excluded.
+            If left to None, the last linear layer is automatically identified and excluded.
     """
 
     weights_bitwidth: int = 8
@@ -83,7 +84,7 @@ class BrevitasQuantizationConfig:
     apply_gptq: bool = False
     gptq_act_order: Optional[bool] = None
     device: str = "auto"
-    exclude_last_layer: bool = True
+    layers_to_exclude: Optional[List] = None
     gpu_device_map: Optional[Dict[int, float]] = None
     cpu_device_map: Optional[Dict[str, float]] = None
 

--- a/optimum/amd/brevitas/configuration.py
+++ b/optimum/amd/brevitas/configuration.py
@@ -59,6 +59,8 @@ class BrevitasQuantizationConfig:
             Whether to apply GPTQ algorithm for quantizing the weights.
         gptq_act_order (`Optional[bool]`, defaults to `None`):
             Whether to use activations reordering (act-order, also known as desc-act) when `apply_gptq=True`. If `apply_gptq=True`, defaults to `False`.
+        exclude_last_layer ('bool', defaults to True):
+            Whether to exclude the last layer from quantization and leave it in its original precision.
     """
 
     weights_bitwidth: int = 8

--- a/optimum/amd/brevitas/configuration.py
+++ b/optimum/amd/brevitas/configuration.py
@@ -83,7 +83,7 @@ class BrevitasQuantizationConfig:
     apply_gptq: bool = False
     gptq_act_order: Optional[bool] = None
     device: str = "auto"
-    exclude_last_layer: bool = True,
+    exclude_last_layer: bool = (True,)
     gpu_device_map: Optional[Dict[int, float]] = None
     cpu_device_map: Optional[Dict[str, float]] = None
 

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -180,9 +180,9 @@ class BrevitasQuantizer(OptimumQuantizer):
         if quantization_config.exclude_last_layer:
             last_layer = model.get_output_embeddings()
             # Extract last layer name
-            full_layer_name = [n for (n,m) in model.named_modules() if m == last_layer][0]
+            full_layer_name = [n for (n, m) in model.named_modules() if m == last_layer][0]
             # Remove the prefix
-            layer_name.append(full_layer_name.split('.')[-1])
+            layer_name.append(full_layer_name.split(".")[-1])
 
         # We do not quantize embedding and last fully connected layer
         model = quantize_model(

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -144,7 +144,8 @@ class BrevitasQuantizer(OptimumQuantizer):
             if len(full_layer_name) > 0:
                 full_layer_name = full_layer_name[0]
                 # Remove the prefix
-                layer_name_to_exclude.append(full_layer_name.split(".")[-1])
+                layer_name_suffix = full_layer_name.split(".")[-1]
+                layer_name_to_exclude.append(layer_name_suffix)
             else:
                 logger.info("Last linear layer was not found. All layers will be quantized")
         else:

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -141,7 +141,7 @@ class BrevitasQuantizer(OptimumQuantizer):
             last_layer = self.model.get_output_embeddings()
             # Extract last layer name
             full_layer_name = [n for (n, m) in self.model.named_modules() if m == last_layer]
-            if full_layer_name > 0:
+            if len(full_layer_name) > 0:
                 full_layer_name = full_layer_name[0]
                 # Remove the prefix
                 layer_name_to_exclude.append(full_layer_name.split(".")[-1])

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -176,11 +176,20 @@ class BrevitasQuantizer(OptimumQuantizer):
         else:
             device = next(model.parameters()).device
 
+        layer_name = []
+        if quantization_config.exclude_last_layer:
+            last_layer = model.get_output_embeddings()
+            # Extract last layer name
+            full_layer_name = [n for (n,m) in model.named_modules() if m == last_layer][0]
+            # Remove the prefix
+            layer_name.append(full_layer_name.split('.')[-1])
+
         # We do not quantize embedding and last fully connected layer
         model = quantize_model(
             model,
             dtype=dtype,
             device=device,
+            name_blacklist=layer_name,
             weight_quant_format="int",
             weight_quant_type="sym" if quantization_config.weights_symmetric else "asym",
             weight_bit_width=quantization_config.weights_bitwidth,


### PR DESCRIPTION
Probably not the cleanest of solution, suggestions are appreciated.

Quantization function can filter out layers by name suffix (i.e., no layers prefix), or based on some specific features of the layer itself (e.g., number of input channel, output channel, etc.).

The option to filter out based on features of the layer works differently and requires a different interface but it all boils down to what is more reliable for identifying the last layer of a LLM model.