### PR TITLE
[RyzenAI] Add default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,6 @@ For more information on quantization refer to [Model Quantization](https://ryzen
 
 To load a model and run inference with RyzenAI, you can just replace your `AutoModelForXxx` class with the corresponding `RyzenAIModelForXxx` class. 
 
-The `RyzenAIModelForXxx` requires a runtime configuration file. A default version of this runtime configuration file can be found in the Ryzen AI VOE package, extracted during installation under the name `vaip_config.json`.
-For more information refer to [runtime-configuration-file](https://ryzenai.docs.amd.com/en/latest/runtime_setup.html#runtime-configuration-file)
-
 ```diff
 import requests
 from PIL import Image
@@ -108,7 +105,7 @@ image = Image.open(requests.get(url, stream=True).raw)
 
 model_id = <path of the model>
 - model = AutoModelForImageClassification.from_pretrained(model_id)
-+ model = RyzenAIModelForImageClassification.from_pretrained(model_id, vaip_config=<path to config file>)
++ model = RyzenAIModelForImageClassification.from_pretrained(model_id)
 feature_extractor = AutoFeatureExtractor.from_pretrained(model_id)
 cls_pipe = pipeline("image-classification", model=model, feature_extractor=feature_extractor)
 outputs = cls_pipe(image)

--- a/docs/source/ryzenai/overview.mdx
+++ b/docs/source/ryzenai/overview.mdx
@@ -22,6 +22,8 @@ Note:
 The RyzenAI Model requires a runtime configuration file. A default version of this runtime configuration file can be found in the Ryzen AI VOE package, extracted during installation under the name `vaip_config.json`.
 For more information refer to [runtime-configuration-file](https://ryzenai.docs.amd.com/en/latest/runtime_setup.html#runtime-configuration-file)
 
+In case no runtime configuration file is provided, the library will use the configuration defined in RyzenAIXXX model class. For available configs see [ryzenai/configs/](https://github.com/huggingface/optimum-amd/tree/main/optimum/amd/ryzenai/configs/).
+
 ### Install Optimum-amd
 
 ```bash
@@ -51,11 +53,7 @@ RyzenAI provides pre-optimized models for various tasks such as image classifica
 
 >>> model_id = "amd/resnet50"
 
->>> # The path and name of the runtime configuration file. A default version of this runtime configuration
->>> # file can be found in the Ryzen AI VOE package, extracted during installation under the name `vaip_config.json`.
->>> vaip_config = ".\\vaip_config.json"
-
->>> model = RyzenAIModelForImageClassification.from_pretrained(model_id, vaip_config=vaip_config)
+>>> model = RyzenAIModelForImageClassification.from_pretrained(model_id)
 >>> processor = AutoImageProcessor.from_pretrained(model_id)
 
 >>> # Load image
@@ -99,11 +97,7 @@ Ryzen pre-optimized models are not compatible with transformer pipelines for inf
 >>> #  See [quantize.py](https://huggingface.co/mohitsha/timm-resnet18-onnx-quantized-ryzen/blob/main/quantize.py) for more details on quantization.
 >>> quantized_model_path = "mohitsha/timm-resnet18-onnx-quantized-ryzen"
 
->>> # The path and name of the runtime configuration file. A default version of this runtime configuration
->>> # file can be found in the Ryzen AI VOE package, extracted during installation under the name `vaip_config.json`.
->>> vaip_config = ".\\vaip_config.json"
-
->>> model = RyzenAIModelForImageClassification.from_pretrained(quantized_model_path, vaip_config=vaip_config)
+>>> model = RyzenAIModelForImageClassification.from_pretrained(quantized_model_path)
 
 >>> config = PretrainedConfig.from_pretrained(quantized_model_path)
 
@@ -144,11 +138,7 @@ See below example for Image classification.
 >>> # See [quantize.py](https://huggingface.co/mohitsha/transformers-resnet18-onnx-quantized-ryzen/blob/main/quantize.py) for more details on quantization.
 >>> quantized_model_path = "mohitsha/transformers-resnet18-onnx-quantized-ryzen"
 
->>> # The path and name of the runtime configuration file. A default version of this runtime configuration
->>> # file can be found in the Ryzen AI VOE package, extracted during installation under the name `vaip_config.json`.
->>> vaip_config = ".\\vaip_config.json"
-
->>> model = RyzenAIModelForImageClassification.from_pretrained(quantized_model_path, vaip_config=vaip_config)
+>>> model = RyzenAIModelForImageClassification.from_pretrained(quantized_model_path)
 >>> feature_extractor = AutoFeatureExtractor.from_pretrained(quantized_model_path)
 
 >>> cls_pipe = pipeline("image-classification", model=model, feature_extractor=feature_extractor)

--- a/docs/source/ryzenai/package_reference/pipelines.mdx
+++ b/docs/source/ryzenai/package_reference/pipelines.mdx
@@ -9,7 +9,6 @@ Licensed under the MIT License.
 ### Computer vision
 
 [[autodoc]] ryzenai.pipelines.TimmImageClassificationPipeline
-- all
 
 Example usage:
 
@@ -29,7 +28,6 @@ print(pipe(image))
 ```
 
 [[autodoc]] ryzenai.pipelines.YoloObjectDetectionPipeline
-- all
 
 Supported model types
 * yolox

--- a/docs/source/ryzenai/usage_guides/pipelines.mdx
+++ b/docs/source/ryzenai/usage_guides/pipelines.mdx
@@ -7,12 +7,6 @@ Currently the supported tasks are:
 * `image-classification`
 * `object-detection` (Supported model types - [yolox, yolov3, yolov5, yolov8](https://huggingface.co/models?other=RyzenAI&sort=trending&search=amd%2Fyolo))
 
-<Tip warning={true}>
-The RyzenAI pipelines requires a runtime configuration file for inference. A default version of this runtime configuration file can be found in the Ryzen AI VOE package, extracted during installation under the name `vaip_config.json`.
-
-For more information refer to [runtime-configuration-file](https://ryzenai.docs.amd.com/en/latest/runtime_setup.html#runtime-configuration-file)
-</Tip>
-
 ## The pipeline abstraction
 The pipeline abstraction is a wrapper around all the available pipelines for specific tasks. The pipeline() function automatically loads a default model and tokenizer/feature-extractor capable of performing inference for your task.
 
@@ -21,7 +15,7 @@ The pipeline abstraction is a wrapper around all the available pipelines for spe
 ```python
 >>> from optimum.amd.ryzenai import pipeline
 
->>> detector = pipeline("object-detection", vaip_config=vaip_config_patj)
+>>> detector = pipeline("object-detection")
 ```
 
 2. Pass your input text/image to the [`~pipelines.pipeline`] function:
@@ -69,7 +63,7 @@ Once you have picked an appropriate model, you can create the [`~ryzenai.pipelin
 >>> # Hugging Face hub model-id with the quantized ONNX model
 >>> model_id = "mohitsha/timm-resnet18-onnx-quantized-ryzen"
 
->>> pipe = pipeline("image-classification", model=model_id, vaip_config="vaip_config.json")
+>>> pipe = pipeline("image-classification", model=model_id)
 >>> print(pipe(image))
 ```
 
@@ -88,7 +82,7 @@ It is also possible to load with the `RyzenModelForXXX` class. For example, here
 
 >>> # Hugging Face hub model-id with the quantized ONNX model
 >>> model_id = "mohitsha/timm-resnet18-onnx-quantized-ryzen"
->>> model = RyzenAIModelForImageClassification.from_pretrained(model_id, vaip_config="vaip_config.json")
+>>> model = RyzenAIModelForImageClassification.from_pretrained(model_id)
 
 >>> pipe = pipeline("image-classification", model=model)
 >>> print(pipe(image))
@@ -111,6 +105,6 @@ Note for a few models, `model_type` and/or `image_preprocessor` has to be provid
 
 >>> model_id = "amd/yolox-s"
 
->>> detector = pipeline("object-detection", model=model_id, vaip_config="vaip_config.json", model_type="yolox")
+>>> detector = pipeline("object-detection", model=model_id, model_type="yolox")
 >>> detector = pipe(image)
 ```

--- a/optimum/amd/ryzenai/__init__.py
+++ b/optimum/amd/ryzenai/__init__.py
@@ -18,7 +18,7 @@ _import_structure = {
     ],
     "quantization": ["RyzenAIOnnxQuantizer"],
     "pipelines": ["pipeline"],
-    "utils": ["DEFAULT_VAIP_CONFIG", "DEFAULT_VAIP_CONFIG_MATMUL"],
+    "utils": ["DEFAULT_VAIP_CONFIG"],
 }
 
 
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     )
     from .pipelines import pipeline
     from .quantization import RyzenAIOnnxQuantizer
-    from .utils import DEFAULT_VAIP_CONFIG, DEFAULT_VAIP_CONFIG_MATMUL
+    from .utils import DEFAULT_VAIP_CONFIG
 else:
     import sys
 

--- a/optimum/amd/ryzenai/__init__.py
+++ b/optimum/amd/ryzenai/__init__.py
@@ -18,7 +18,7 @@ _import_structure = {
     ],
     "quantization": ["RyzenAIOnnxQuantizer"],
     "pipelines": ["pipeline"],
-    "version": ["__version__"],
+    "utils": ["DEFAULT_VAIP_CONFIG", "DEFAULT_VAIP_CONFIG_MATMUL"],
 }
 
 
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     )
     from .pipelines import pipeline
     from .quantization import RyzenAIOnnxQuantizer
-    from .version import __version__
+    from .utils import DEFAULT_VAIP_CONFIG, DEFAULT_VAIP_CONFIG_MATMUL
 else:
     import sys
 

--- a/optimum/amd/ryzenai/configs/vaip_config.json
+++ b/optimum/amd/ryzenai/configs/vaip_config.json
@@ -1,0 +1,306 @@
+{
+ "passes": [
+  {
+   "name": "init",
+   "plugin": "vaip-pass_init"
+  },
+  {
+   "name": "fuse_resize_norm",
+   "plugin": "vaip-pass_py_ext",
+   "disabled": false,
+   "pyExt": {
+    "moduleName": "voe.passes.fuse_resize_norm",
+    "methodName": "rules"
+   }
+  },
+  {
+   "name": "fuse_softmax",
+   "plugin": "vaip-pass_py_ext",
+   "disabled": false,
+   "pyExt": {
+    "moduleName": "voe.passes.fuse_softmax",
+    "methodName": "rules"
+   }
+  },
+  {
+   "name": "fuse_topk",
+   "plugin": "vaip-pass_py_ext",
+   "disabled": false,
+   "pyExt": {
+    "moduleName": "voe.passes.fuse_topk",
+    "methodName": "rules"
+   }
+  },
+  {
+   "name": "fuse_decode_filter_boxes",
+   "plugin": "vaip-pass_py_ext",
+   "disabled": false,
+   "pyExt": {
+    "moduleName": "voe.passes.fuse_decode_filter_boxes",
+    "methodName": "rules"
+   }
+  },
+  {
+   "name": "fuse_NMS",
+   "plugin": "vaip-pass_py_ext",
+   "disabled": true,
+   "pyExt": {
+    "moduleName": "voe.passes.fuse_NMS",
+    "methodName": "rules"
+   }
+  },
+  {
+   "name": "fuse_DPU",
+   "plugin": "vaip-pass_level1_dpu",
+   "passDpuParam": {
+    "subPass": [
+        {
+      "_comment" : "# issue 1048",
+      "name": "convert_ending_blacklist_ops_to_unknown_op",
+      "plugin": "vaip-pass_convert_ending_blacklist_ops_to_unknown_op",
+      "disabled": false
+        },
+        {
+      "_comment" : "test case : yolov5s6",
+      "name": "manual_partition",
+      "plugin": "vaip-pass_manual_partition",
+      "disabled": true,
+      "manualPartition": {
+       "fromOps": [
+        "1745/duplicated_token_14",
+        "1764/duplicated_token_10",
+        "1783/duplicated_token_6",
+        "1802/duplicated_token_2"
+       ],
+       "toOps": [
+           "2895"
+       ]
+      }
+     },
+     {
+      "name": "dynamic_input_batch",
+      "plugin": "vaip-pass_dynamic_input_batch"
+     },
+     {
+      "_comment" : "test case q_operator_resnet50",
+      "name": "convert_qlinear_to_qdq",
+      "plugin": "vaip-pass_py_ext",
+      "disabled": true,
+      "enableGc": true,
+      "pyExt": {
+       "moduleName": "voe.passes.convert_qlinear_to_qdq",
+       "methodName": "rules"
+      }
+     },
+     {
+      "name": "create_const_op",
+      "plugin": "vaip-pass_create_const_op"
+     },
+     {
+      "name": "convert_to_xir_op",
+      "plugin": "vaip-pass_py_ext",
+      "disabled" : false,
+      "pyExt": {
+       "moduleName": "voe.passes.convert_to_xir_op",
+       "methodName": "rules"
+      }
+     },
+     {
+      "name": "to_xir",
+      "plugin": "vaip-pass_to_xir_ops"
+     },
+     {
+      "name": "remove_extra_q_dq",
+      "plugin": "vaip-pass_remove_extra_q_dq"
+     },
+     {
+      "name": "merge_add_into_conv_bias",
+      "plugin": "vaip-pass_merge_add_into_conv_bias"
+     },
+     {
+      "name": "merge_fix",
+      "plugin": "vaip-pass_py_ext",
+      "enableGc": true,
+      "pyExt": {
+       "moduleName": "voe.passes.merge_fix",
+       "methodName": "rules"
+      }
+     },
+     {
+      "name": "layoutransform",
+      "plugin": "vaip-pass_layout_transform_via_adding_transpose"
+     },
+     {
+      "name": "gc_after_layout_transform",
+      "plugin": "vaip-pass_remove_isolated_node"
+     },
+     {
+      "name": "fuse_transpose",
+      "plugin": "vaip-pass_fuse_transpose",
+      "enableGc": true
+     },
+     {
+      "name": "gc_after_fuse_transpose",
+      "plugin": "vaip-pass_remove_isolated_node"
+     },
+     {
+      "name": "remove_identity",
+      "plugin": "vaip-pass_remove_identity",
+      "logVerbosity": 1
+     },
+     {
+      "name": "add_fix_after_const",
+      "plugin": "vaip-pass_const_add_fix"
+     },
+     {
+       "_comment" : "test case 41 see issue #611 #626 for more detail",
+      "name": "merge_duplicated_fix",
+      "plugin": "vaip-pass_merge_duplicated_fix",
+      "disabled": true,
+      "enableGc": true
+     },
+     {
+      "_comment": "test case 112",
+      "name": "remove_reshape_fix",
+      "plugin": "vaip-pass_py_ext",
+      "pyExt": {
+       "moduleName": "voe.passes.remove_reshape_fix",
+       "methodName": "rules"
+      }
+     },
+     {
+      "_comment" : "test case 5",
+      "name": "const_fold_batchnorm_to_scale",
+      "plugin": "vaip-pass_py_ext",
+      "pyExt": {
+       "moduleName": "voe.passes.const_fold_batchnorm_to_scale",
+       "methodName": "rules"
+      }
+     },
+     {
+      "name": "const_fold_transpose",
+      "plugin": "vaip-pass_const_fold_transpose"
+     },
+     {
+      "name": "merge_pad",
+      "plugin": "vaip-pass_merge_pad"
+     },
+     {
+      "name": "merge_hard_sigmoid",
+      "plugin": "vaip-pass_merge_hard_sigmoid"
+     },
+     {
+      "_comment" : "test case 112",
+      "name": "merge_mul",
+      "plugin": "vaip-pass_py_ext",
+      "pyExt": {
+       "moduleName": "voe.passes.merge_mul",
+       "methodName": "rules"
+      }
+     },
+     {
+      "name": "merge_consecutive_fix",
+      "plugin": "vaip-pass_merge_consecutive_fix",
+      "disabled": true,
+      "enableLog": true,
+      "logVerbosity": 1
+     },
+     {
+      "name": "graph_output_add_node",
+      "plugin": "vaip-pass_graph_output_add_node",
+      "disabled": true
+     },
+     {
+      "_comment" : "test case 20",
+      "name": "convert_transpose_add_fix_input_fix_input",
+      "plugin": "vaip-pass_py_ext",
+      "disabled": true,
+      "pyExt": {
+       "moduleName": "voe.passes.convert_transpose_add_fix_input_fix_input",
+       "methodName": "process"
+      }
+     },
+     {
+      "_comment" : "test case 100",
+      "name": "convert_transpose_fix_pad_fix_input",
+      "plugin": "vaip-pass_py_ext",
+      "disabled": true,
+      "pyExt": {
+       "moduleName": "voe.passes.convert_transpose_fix_pad_fix_input",
+       "methodName": "process"
+      }
+     },
+     {
+      "_comment" : "test case 100",
+      "name": "convert_transpose_fix_input",
+      "plugin": "vaip-pass_py_ext",
+      "enableGc": true,
+      "disabled": true,
+      "pyExt": {
+       "moduleName": "voe.passes.convert_transpose_fix_input",
+       "methodName": "process"
+      }
+     },
+     {
+      "_comment": "test case 110",
+      "name": "convert_softmax_to_hard_softmax",
+      "plugin": "vaip-pass_py_ext",
+      "disabled" : true,
+      "pyExt": {
+       "moduleName": "voe.passes.convert_softmax_to_hard_softmax",
+       "methodName": "rules"
+      }
+     },
+     {
+      "_comment": "test case 43",
+      "name": "remove_top_transpose",
+      "plugin": "vaip-pass_merge_input_transpose",
+      "disabled": true,
+      "enableGc": true
+     },
+     {
+      "_comment": "test case 110",
+      "name": "remove_bottom_transpose",
+      "plugin": "vaip-pass_remove_bottom_transpose",
+      "disabled": true,
+      "enableGc": true
+      },
+     {
+      "name": "final_gc",
+      "plugin": "vaip-pass_remove_isolated_node"
+     }
+    ],
+    "xcompilerAttrs": {
+        "debug_mode" : {
+            "stringValue" : "performance"
+        },
+        "dpu_subgraph_num" : {
+            "intValue" : 32
+        },
+        "opt_level" : {
+            "intValue" : 0
+        },
+        "dump_subgraph_ops" : {
+            "boolValue" : false
+        },
+        "profile" : {
+            "intValue" : 0
+        },
+        "prefetch" : {
+            "boolValue" : false
+        },
+        "preassign" : {
+            "boolValue" : false
+        },
+        "disable_std_quant" : {
+            "boolValue" : false
+        },
+        "concat_skip_code_gen" : {
+            "boolValue" : false
+        }
+    },
+    "minimum_num_of_conv": 2
+   }
+  }
+ ]
+}

--- a/optimum/amd/ryzenai/modeling.py
+++ b/optimum/amd/ryzenai/modeling.py
@@ -32,6 +32,7 @@ from transformers.file_utils import add_start_docstrings
 from transformers.modeling_outputs import ImageClassifierOutput, ModelOutput
 
 from .utils import (
+    DEFAULT_VAIP_CONFIG,
     ONNX_WEIGHTS_NAME,
     ONNX_WEIGHTS_NAME_STATIC,
     validate_provider_availability,
@@ -41,14 +42,6 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 CONFIG_NAME = "config.json"
-
-
-class classproperty:
-    def __init__(self, getter):
-        self.getter = getter
-
-    def __get__(self, instance, owner):
-        return self.getter(owner)
 
 
 class RyzenAIModel(OptimizedModel):
@@ -75,6 +68,7 @@ class RyzenAIModel(OptimizedModel):
 
     model_type = "onnx_model"
     auto_model_class = AutoModel
+    default_vaip_config = DEFAULT_VAIP_CONFIG
 
     def shared_attributes_init(
         self,
@@ -282,11 +276,9 @@ class RyzenAIModel(OptimizedModel):
 
         if provider == "VitisAIExecutionProvider":
             if vaip_config is None and "config_file" not in (provider_options or {}):
-                raise ValueError(
-                    "No config file provided. Please provide the necessary config file for inference with RyzenAI"
-                )
-
-            if vaip_config and provider_options and "config_file" in provider_options:
+                logger.warning(f"No config file provided. Using default config: {cls.default_vaip_config}.\n")
+                vaip_config = cls.default_vaip_config
+            elif vaip_config and provider_options and "config_file" in provider_options:
                 raise ValueError(
                     "Configuration file paths were found in both `vaip_config` and `provider_options`."
                     "To avoid conflicts, please specify the configuration file path in either `vaip_config`"

--- a/optimum/amd/ryzenai/modeling.py
+++ b/optimum/amd/ryzenai/modeling.py
@@ -276,9 +276,11 @@ class RyzenAIModel(OptimizedModel):
 
         if provider == "VitisAIExecutionProvider":
             if vaip_config is None and "config_file" not in (provider_options or {}):
-                logger.warning(f"No config file provided. Using default config: {cls.default_vaip_config}.\n")
+                logger.warning(
+                    f"No Ryzen AI configuration file was provided. Using default: {cls.default_vaip_config}.\n"
+                )
                 vaip_config = cls.default_vaip_config
-            elif vaip_config and provider_options and "config_file" in provider_options:
+            elif vaip_config is not None and provider_options is not None and "config_file" in provider_options:
                 raise ValueError(
                     "Configuration file paths were found in both `vaip_config` and `provider_options`."
                     "To avoid conflicts, please specify the configuration file path in either `vaip_config`"

--- a/optimum/amd/ryzenai/pipelines/__init__.py
+++ b/optimum/amd/ryzenai/pipelines/__init__.py
@@ -89,7 +89,7 @@ def load_model(
         ort_model_class = SUPPORTED_TASKS[task]["class"][0]
 
         model = ort_model_class.from_pretrained(
-            model_id, vaip_config=vaip_config, use_auth_token=token, revision=revision, provider="CPUExecutionProvider"
+            model_id, vaip_config=vaip_config, use_auth_token=token, revision=revision
         )
     elif isinstance(model, RyzenAIModel):
         model_id = None
@@ -103,8 +103,8 @@ def load_model(
 
 def pipeline(
     task,
-    vaip_config: str,
     model: Optional[Any] = None,
+    vaip_config: Optional[str] = None,
     model_type: Optional[str] = None,
     feature_extractor: Optional[Union[str, "PreTrainedFeatureExtractor"]] = None,
     image_processor: Optional[Union[str, BaseImageProcessor]] = None,
@@ -124,12 +124,12 @@ def pipeline(
             The task defining which pipeline will be returned. Available tasks include:
             - "image-classification"
             - "object-detection"
-        vaip_config (`str`):
-            Runtime configuration file for inference with Ryzen IPU. A default config file can be found in the Ryzen AI VOE package,
-            extracted during installation under the name `vaip_config.json`.
         model (`Optional[Any]`, defaults to `None`):
             The model that will be used by the pipeline to make predictions. This can be a model identifier or an
             actual instance of a pretrained model. If not provided, the default model for the specified task will be loaded.
+        vaip_config (`Optional[str]`, defaults to `None`):
+            Runtime configuration file for inference with Ryzen IPU. A default config file can be found in the Ryzen AI VOE package,
+            extracted during installation under the name `vaip_config.json`.
         model_type (`Optional[str]`, defaults to `None`):
             Model type for the model
         feature_extractor (`Union[str, "PreTrainedFeatureExtractor"]`, defaults to `None`):

--- a/optimum/amd/ryzenai/utils.py
+++ b/optimum/amd/ryzenai/utils.py
@@ -2,11 +2,15 @@
 # Licensed under the MIT License.
 
 
+import os.path as osp
+
 import onnxruntime as ort
 
 
 ONNX_WEIGHTS_NAME = "model.onnx"
 ONNX_WEIGHTS_NAME_STATIC = "model_static.onnx"
+
+DEFAULT_VAIP_CONFIG = osp.normpath(osp.join(osp.dirname(__file__), "./configs/vaip_config.json"))
 
 
 def validate_provider_availability(provider: str):

--- a/optimum/amd/ryzenai/utils.py
+++ b/optimum/amd/ryzenai/utils.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 
-import os.path as osp
+import os
 
 import onnxruntime as ort
 
@@ -10,7 +10,7 @@ import onnxruntime as ort
 ONNX_WEIGHTS_NAME = "model.onnx"
 ONNX_WEIGHTS_NAME_STATIC = "model_static.onnx"
 
-DEFAULT_VAIP_CONFIG = osp.normpath(osp.join(osp.dirname(__file__), "./configs/vaip_config.json"))
+DEFAULT_VAIP_CONFIG = os.path.normpath(os.path.join(os.path.dirname(__file__), "./configs/vaip_config.json"))
 
 
 def validate_provider_availability(provider: str):

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     entry_points={"console_scripts": ["amdrun=optimum.amd.cli:amdrun"]},
     install_requires=INSTALL_REQUIRE,
     extras_require=EXTRAS_REQUIRE,
-    package_data={'optimum': ['amd/ryzenai/configs/*.json']},
+    package_data={"optimum": ["amd/ryzenai/configs/*.json"]},
     include_package_data=True,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
     entry_points={"console_scripts": ["amdrun=optimum.amd.cli:amdrun"]},
     install_requires=INSTALL_REQUIRE,
     extras_require=EXTRAS_REQUIRE,
+    package_data={'optimum': ['amd/ryzenai/configs/*.json']},
     include_package_data=True,
     zip_safe=False,
 )

--- a/tests/ryzenai/test_modeling.py
+++ b/tests/ryzenai/test_modeling.py
@@ -16,7 +16,6 @@ from parameterized import parameterized
 from PIL import Image
 from testing_utils import (
     DEFAULT_CACHE_DIR,
-    DEFAULT_VAIP_CONFIG,
     RYZEN_PREQUANTIZED_MODEL_CUSTOM_TASKS,
     RYZEN_PREQUANTIZED_MODEL_IMAGE_CLASSIFICATION,
     RYZEN_PREQUANTIZED_MODEL_IMAGE_SEGMENTATION,
@@ -70,7 +69,7 @@ class RyzenAIModelIntegrationTest(unittest.TestCase, RyzenAITestCaseMixin):
         os.environ["XLNX_ENABLE_CACHE"] = "0"
         os.environ["XLNX_USE_SHARED_CONTEXT"] = "1"
 
-        model = RyzenAIModel.from_pretrained(self.TEST_MODEL_ID, vaip_config=DEFAULT_VAIP_CONFIG)
+        model = RyzenAIModel.from_pretrained(self.TEST_MODEL_ID)
         self.assertIsInstance(model.model, onnxruntime.InferenceSession)
         self.assertListEqual(model.providers, ["VitisAIExecutionProvider", "CPUExecutionProvider"])
 
@@ -87,7 +86,7 @@ class RyzenAIModelIntegrationTest(unittest.TestCase, RyzenAITestCaseMixin):
             os.environ["XLNX_ENABLE_CACHE"] = "0"
             os.environ["XLNX_USE_SHARED_CONTEXT"] = "1"
 
-            model = RyzenAIModel.from_pretrained(self.TEST_MODEL_ID, vaip_config=DEFAULT_VAIP_CONFIG)
+            model = RyzenAIModel.from_pretrained(self.TEST_MODEL_ID)
             model.save_pretrained(tmpdirname)
             folder_contents = os.listdir(tmpdirname)
             self.assertTrue("ResNet_int.onnx" in folder_contents)
@@ -102,9 +101,8 @@ class RyzenAIModelForImageClassificationIntegrationTest(unittest.TestCase, Ryzen
 
         file_name, ort_input, input_name = load_model_and_input(model_id)
 
-        vaip_config = DEFAULT_VAIP_CONFIG
         outputs_ipu, outputs_cpu = self.prepare_outputs(
-            model_id, RyzenAIModelForImageClassification, ort_input, vaip_config, cache_dir, cache_key, file_name
+            model_id, RyzenAIModelForImageClassification, ort_input, cache_dir, cache_key, file_name
         )
 
         self.assertIn("logits", outputs_ipu)
@@ -128,7 +126,7 @@ class RyzenAIModelForImageClassificationIntegrationTest(unittest.TestCase, Ryzen
         os.environ["XLNX_ENABLE_CACHE"] = "0"
         os.environ["XLNX_USE_SHARED_CONTEXT"] = "1"
 
-        pipe = pipeline("image-classification", model=model_id, vaip_config=self.VAIP_CONFIG)
+        pipe = pipeline("image-classification", model=model_id)
 
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(url, stream=True).raw)
@@ -153,9 +151,8 @@ class RyzenAIModelForObjectDetectionIntegrationTest(unittest.TestCase, RyzenAITe
 
         file_name, ort_input, input_name = load_model_and_input(model_id)
 
-        vaip_config = DEFAULT_VAIP_CONFIG
         outputs_ipu, outputs_cpu = self.prepare_outputs(
-            model_id, RyzenAIModelForObjectDetection, ort_input, vaip_config, cache_dir, cache_key, file_name
+            model_id, RyzenAIModelForObjectDetection, ort_input, cache_dir, cache_key, file_name
         )
 
         for output_ipu, output_cpu in zip(outputs_ipu.values(), outputs_cpu.values()):
@@ -176,7 +173,7 @@ class RyzenAIModelForObjectDetectionIntegrationTest(unittest.TestCase, RyzenAITe
         os.environ["XLNX_USE_SHARED_CONTEXT"] = "1"
 
         model_id = RYZEN_PREQUANTIZED_MODEL_OBJECT_DETECTION[model_arch]
-        pipe = pipeline("object-detection", model=model_id, vaip_config=self.VAIP_CONFIG, model_type=model_arch)
+        pipe = pipeline("object-detection", model=model_id, model_type=model_arch)
 
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(url, stream=True).raw)
@@ -195,7 +192,7 @@ class RyzenAIModelForObjectDetectionIntegrationTest(unittest.TestCase, RyzenAITe
         os.environ["XLNX_ENABLE_CACHE"] = "0"
         os.environ["XLNX_USE_SHARED_CONTEXT"] = "1"
 
-        pipe = pipeline("object-detection", vaip_config=self.VAIP_CONFIG)
+        pipe = pipeline("object-detection")
 
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(url, stream=True).raw)
@@ -219,9 +216,8 @@ class RyzenAIModelForSemanticSegmentationIntegrationTest(unittest.TestCase, Ryze
 
         file_name, ort_input, input_name = load_model_and_input(model_id)
 
-        vaip_config = DEFAULT_VAIP_CONFIG
         outputs_ipu, outputs_cpu = self.prepare_outputs(
-            model_id, RyzenAIModelForSemanticSegmentation, ort_input, vaip_config, cache_dir, cache_key, file_name
+            model_id, RyzenAIModelForSemanticSegmentation, ort_input, cache_dir, cache_key, file_name
         )
 
         for output_ipu, output_cpu in zip(outputs_ipu.values(), outputs_cpu.values()):
@@ -245,9 +241,8 @@ class RyzenAIModelForImageToImageIntegrationTest(unittest.TestCase, RyzenAITestC
 
         file_name, ort_input, input_name = load_model_and_input(model_id)
 
-        vaip_config = DEFAULT_VAIP_CONFIG
         outputs_ipu, outputs_cpu = self.prepare_outputs(
-            model_id, RyzenAIModelForImageToImage, ort_input, vaip_config, cache_dir, cache_key, file_name
+            model_id, RyzenAIModelForImageToImage, ort_input, cache_dir, cache_key, file_name
         )
 
         for output_ipu, output_cpu in zip(outputs_ipu.values(), outputs_cpu.values()):
@@ -272,9 +267,8 @@ class RyzenAIModelForCustomTasksIntegrationTest(unittest.TestCase, RyzenAITestCa
         file_name, ort_input, input_name = load_model_and_input(model_id)
         ort_input = {input_name: ort_input}
 
-        vaip_config = DEFAULT_VAIP_CONFIG
         outputs_ipu, outputs_cpu = self.prepare_outputs(
-            model_id, RyzenAIModelForCustomTasks, ort_input, vaip_config, cache_dir, cache_key, file_name
+            model_id, RyzenAIModelForCustomTasks, ort_input, cache_dir, cache_key, file_name
         )
 
         for output_ipu, output_cpu in zip(outputs_ipu.values(), outputs_cpu.values()):

--- a/tests/ryzenai/test_modeling.py
+++ b/tests/ryzenai/test_modeling.py
@@ -77,10 +77,6 @@ class RyzenAIModelIntegrationTest(unittest.TestCase, RyzenAITestCaseMixin):
         with self.assertRaises(ValueError):
             RyzenAIModel.from_pretrained(self.TEST_MODEL_ID, vaip_config=".\\invalid_path\\vaip_config.json")
 
-    def test_load_model_no_config_path(self):
-        with self.assertRaises(ValueError):
-            RyzenAIModel.from_pretrained(self.TEST_MODEL_ID)
-
     def test_save_model(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             os.environ["XLNX_ENABLE_CACHE"] = "0"

--- a/tests/ryzenai/test_quantization.py
+++ b/tests/ryzenai/test_quantization.py
@@ -13,7 +13,6 @@ from datasets import load_dataset
 from parameterized import parameterized
 from testing_utils import (
     DEFAULT_CACHE_DIR,
-    DEFAULT_VAIP_CONFIG,
     PYTORCH_TIMM_MODEL,
     PYTORCH_TIMM_MODEL_SUBSET,
     RyzenAITestCaseMixin,
@@ -113,13 +112,12 @@ class TestTimmQuantization(unittest.TestCase, RyzenAITestCaseMixin):
         # inference
         cache_dir = DEFAULT_CACHE_DIR
         cache_key = model_name.replace("/", "_").lower()
-        vaip_config = DEFAULT_VAIP_CONFIG
 
         evaluation_set = load_dataset(dataset_name, split="validation", streaming=True, trust_remote_code=True)
         ort_inputs = preprocess_fn(next(iter(evaluation_set)), transforms)["pixel_values"].unsqueeze(0)
 
         outputs_ipu, outputs_cpu = self.prepare_outputs(
-            quantization_dir.name, RyzenAIModelForImageClassification, ort_inputs, vaip_config, cache_dir, cache_key
+            quantization_dir.name, RyzenAIModelForImageClassification, ort_inputs, cache_dir, cache_key
         )
 
         self.assertTrue(torch.allclose(outputs_ipu.logits, outputs_cpu.logits, atol=1e-4))

--- a/tests/ryzenai/testing_utils.py
+++ b/tests/ryzenai/testing_utils.py
@@ -46,9 +46,7 @@ class RyzenAITestCaseMixin:
         if cache_key:
             provider_options["cacheKey"] = cache_key
 
-        model_instance = model_class.from_pretrained(
-            model_id, file_name=file_name, provider_options=provider_options
-        )
+        model_instance = model_class.from_pretrained(model_id, file_name=file_name, provider_options=provider_options)
 
         if isinstance(ort_input, dict):
             outputs = model_instance(**ort_input)
@@ -57,9 +55,7 @@ class RyzenAITestCaseMixin:
 
         return outputs
 
-    def prepare_outputs(
-        self, model_id, model_class, ort_input, cache_dir=None, cache_key=None, file_name=None
-    ):
+    def prepare_outputs(self, model_id, model_class, ort_input, cache_dir=None, cache_key=None, file_name=None):
         set_seed(SEED)
         output_ipu = self.run_model(
             model_class,

--- a/tests/ryzenai/testing_utils.py
+++ b/tests/ryzenai/testing_utils.py
@@ -10,7 +10,6 @@ from transformers import set_seed
 SEED = 42
 
 BASELINE_JSON = os.path.normpath("./tests/ryzenai/operators_baseline.json")  # For RyzenSDK 1.1
-DEFAULT_VAIP_CONFIG = os.path.normpath("./tests/ryzenai/vaip_config.json")
 
 DEFAULT_CACHE_DIR = "ryzen_cache"
 
@@ -32,7 +31,6 @@ class RyzenAITestCaseMixin:
         ort_input,
         use_cpu_runner,
         compile_reserve_const_data,
-        vaip_config,
         cache_dir=None,
         cache_key=None,
         file_name=None,
@@ -49,7 +47,7 @@ class RyzenAITestCaseMixin:
             provider_options["cacheKey"] = cache_key
 
         model_instance = model_class.from_pretrained(
-            model_id, file_name=file_name, vaip_config=vaip_config, provider_options=provider_options
+            model_id, file_name=file_name, provider_options=provider_options
         )
 
         if isinstance(ort_input, dict):
@@ -60,7 +58,7 @@ class RyzenAITestCaseMixin:
         return outputs
 
     def prepare_outputs(
-        self, model_id, model_class, ort_input, vaip_config, cache_dir=None, cache_key=None, file_name=None
+        self, model_id, model_class, ort_input, cache_dir=None, cache_key=None, file_name=None
     ):
         set_seed(SEED)
         output_ipu = self.run_model(
@@ -69,7 +67,6 @@ class RyzenAITestCaseMixin:
             ort_input,
             use_cpu_runner=0,
             compile_reserve_const_data=0,
-            vaip_config=vaip_config,
             cache_dir=cache_dir,
             cache_key=cache_key,
             file_name=file_name,
@@ -81,7 +78,6 @@ class RyzenAITestCaseMixin:
             ort_input,
             use_cpu_runner=1,
             compile_reserve_const_data=1,
-            vaip_config=vaip_config,
             file_name=file_name,
         )
 


### PR DESCRIPTION
As per title.

User can now skip providing the `vaip_config` as an argument. The model will use default config if none provided

This would allow to truly adapt  to the existing `transformers` interface by just replacing class.
```diff
- model = AutoModelForImageClassification.from_pretrained(model_id)
+ model = RyzenAIModelForImageClassification.from_pretrained(model_id)
```