### PR TITLE
Fix for handling removal of constant nodes with multiple sinks

### DIFF
--- a/optimum/amd/brevitas/export.py
+++ b/optimum/amd/brevitas/export.py
@@ -148,7 +148,8 @@ def replace_matmul_to_matmulinteger(graph: Graph, found_nodes: List[List[str]], 
             graph.remove_node(name)
 
         graph.remove_node(deq_linear.prevnodes[0].name)
-        graph.remove_node(deq_linear.prevnodes[1].name)
+        if deq_linear.prevnodes[1].name in graph.nodemap:
+            graph.remove_node(deq_linear.prevnodes[1].name)
         if deq_linear.prevnodes[2].name in graph.nodemap:
             graph.remove_node(deq_linear.prevnodes[2].name)
 
@@ -203,7 +204,8 @@ def replace_gemm_to_matmulinteger(graph: Graph, found_nodes: List[List[str]], no
                 continue
             graph.remove_node(name)
         graph.remove_node(deq_linear.prevnodes[0].name)
-        graph.remove_node(deq_linear.prevnodes[1].name)
+        if deq_linear.prevnodes[1].name in graph.nodemap:
+            graph.remove_node(deq_linear.prevnodes[1].name)
         if deq_linear.prevnodes[2].name in graph.nodemap:
             graph.remove_node(deq_linear.prevnodes[2].name)
 


### PR DESCRIPTION
Occasionally, for large models the calculated scale factors for different quantizers can be identical - in this case, ONNX will sometimes create a single constant node which will connect to both quantize linear layers. This will cause strange things to happen when we replace "fake quantized" operations with QOps.

This is a basic workaround, but a more robust solution is required.