### PR TITLE
Fix: no past_key_value if the model is not FX

### DIFF
--- a/optimum/amd/brevitas/data_utils.py
+++ b/optimum/amd/brevitas/data_utils.py
@@ -61,7 +61,7 @@ def compute_perplexity(model: torch.nn.Module, data: List[Dict], context_length:
             }
 
             # In case we are using torch.fx, we can not have optional inputs, and we have traced the model with past_key_values inputs, thus we need them here as well.
-            if "past_key_values" in sample:
+            if "past_key_values" in sample and isinstance(model, torch.fx.GraphModule):
                 subsample["past_key_values"] = sample["past_key_values"]
 
             # Add BOS token.


### PR DESCRIPTION
Adding `past_key_value` to the input args for a model that has been offloaded and is not an `fx.GraphModule` causes an error due to the caches being on different devices, in the case of Llama2.

This does not happen once the model is a `fx.GraphModule` and is offloaded with the fx-compatible offload_model