### PR TITLE
Fix: handle models without BOS/EOS tokens defined (e.g., Qwen1.5)

### DIFF
--- a/optimum/amd/brevitas/data_utils.py
+++ b/optimum/amd/brevitas/data_utils.py
@@ -65,7 +65,8 @@ def compute_perplexity(model: torch.nn.Module, data: List[Dict], context_length:
                 subsample["past_key_values"] = sample["past_key_values"]
 
             # Add BOS token.
-            subsample["input_ids"][:, 0] = tokenizer.bos_token_id
+            if tokenizer.bos_token_id is not None:
+                subsample["input_ids"][:, 0] = tokenizer.bos_token_id
 
             use_accelerate = hasattr(model, "hf_device_map")
             if not use_accelerate or (use_accelerate and not hasattr(model, "_hf_hook")):
@@ -136,7 +137,8 @@ def get_wikitext2(
                 input_ids = enc["input_ids"][:, start_idx : end_idx + 1]
 
                 # Add BOS token.
-                input_ids[:, 0] = tokenizer.bos_token_id
+                if tokenizer.bos_token_id is not None:
+                    input_ids[:, 0] = tokenizer.bos_token_id
 
                 dataset.append({"input_ids": input_ids, "attention_mask": attention_mask})
                 pbar.update(1)
@@ -187,7 +189,8 @@ def get_c4(
                 input_ids = enc["input_ids"][:, start_idx : end_idx + 1]
 
                 # Add BOS token.
-                input_ids[:, 0] = tokenizer.bos_token_id
+                if tokenizer.eos_token_id is not None:
+                    input_ids[:, 0] = tokenizer.eos_token_id
 
                 dataset.append({"input_ids": input_ids, "attention_mask": attention_mask})
                 pbar.update(1)


### PR DESCRIPTION
Some models don't have BOS/EOS tokens defined (e.g., Qwen1.5), we should handle this case.