### PR TITLE
Fix (brevitas/bias_correction): Add zero-valued bias to linear layers when accelerate is enabled.

### DIFF
--- a/optimum/amd/brevitas/configuration.py
+++ b/optimum/amd/brevitas/configuration.py
@@ -137,5 +137,8 @@ class BrevitasQuantizationConfig:
             self.activations_group_size = None
             self.activations_param_method = None
 
+    def add_bias_to_linear(self):
+        return self.apply_bias_correction and self.device == "auto"
+
     def requires_fx_graph(self):
         return self.activations_equalization == "cross_layer" or self.apply_weight_equalization

--- a/optimum/amd/brevitas/quantizer.py
+++ b/optimum/amd/brevitas/quantizer.py
@@ -244,6 +244,7 @@ class BrevitasQuantizer(OptimumQuantizer):
             apply_bias_correction(
                 model,
                 calibration_dataset,
+                skip_if_no_bias=use_accelerate, # We can't add keys to the state dict if accelerate is being used
             )
             logger.info("Bias Correction applied.")
 
@@ -331,7 +332,7 @@ def apply_calibration(model: torch.nn.Module, dataset: List[Dict]) -> None:
 
 
 @torch.no_grad()
-def apply_bias_correction(model: torch.nn.Module, dataset: List[Dict]) -> None:
-    with bias_correction_mode(model):
+def apply_bias_correction(model: torch.nn.Module, dataset: List[Dict], skip_if_no_bias: bool = False) -> None:
+    with bias_correction_mode(model, skip_if_no_bias=skip_if_no_bias):
         for inps in tqdm(dataset):
             model(**inps)


### PR DESCRIPTION
Corresponds with [this fix](https://github.com/Xilinx/brevitas/pull/962).