### PR TITLE
Unpin pytest and remove todo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,8 @@ except Exception as error:
 # ORT 1.16 is not compatible: https://github.com/Xilinx/Vitis-AI/issues/1343
 INSTALL_REQUIRE = ["optimum", "transformers>=4.38", "onnx", "onnxruntime-extensions"]
 
-# TODO: unpin pytest once https://github.com/huggingface/transformers/pull/29154 is merged & released
 TESTS_REQUIRE = [
-    "pytest<=7.4.4",
+    "pytest",
     "parameterized",
     "evaluate",
     "timm",


### PR DESCRIPTION
While looking into the repo structure, I noticed this `TODO` that seems to be removable because the referenced PR https://github.com/huggingface/transformers/pull/29154 has been merged and released as of v4.39

I'm unfortunately not able to test before opening this PR but happy to make changes as needed