### PR TITLE
Fix (example/brevitas): Allow setting more device options (e.g., 'cuda:1')

### DIFF
--- a/examples/quantization/brevitas/quantize_llm.py
+++ b/examples/quantization/brevitas/quantize_llm.py
@@ -130,7 +130,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--device",
         type=str,
-        choices=["cpu", "cuda:0", "auto"],
         default="auto",
         help='Device to run the example on (e.q., "cpu", "cuda:0", "auto"). "auto" will automatically select the device using HuggingFace Accelerate (choices: [%(choices)s], default: %(default)s).',
     )


### PR DESCRIPTION
Current `choices` param applies arbitrary limitations to what devices can be selected - this should be removed.