### PR TITLE
docs: fix typo in amdgpu/overview

### DIFF
--- a/docs/source/amdgpu/overview.mdx
+++ b/docs/source/amdgpu/overview.mdx
@@ -49,7 +49,7 @@ Hosted wheels are available for ROCm, please check out the [installation instruc
 
 ### Text Generation Inference library
 
-Hugging Face's [Text Generation Inference](https://huggingface.co/docs/text-generation-inference/index) library (TGI) is designed for low latency LLMs serving, and natively supports AMD Instinct MI210, MI250 and MI3O0 GPUs. Please refer to the [Quick Tour section](https://huggingface.co/docs/text-generation-inference/quicktour) for more details.
+Hugging Face's [Text Generation Inference](https://huggingface.co/docs/text-generation-inference/index) library (TGI) is designed for low latency LLMs serving, and natively supports AMD Instinct MI210, MI250 and MI300 GPUs. Please refer to the [Quick Tour section](https://huggingface.co/docs/text-generation-inference/quicktour) for more details.
 
 Using TGI on ROCm with AMD Instinct MI210 or MI250 or MI300 GPUs is as simple as using the docker image [`ghcr.io/huggingface/text-generation-inference:latest-rocm`](https://huggingface.co/docs/text-generation-inference/quicktour).
 


### PR DESCRIPTION
FIx a typo `MI3O0` in documentation. Large "O" character should be replaced with "0" (zero).
It is a trivial typo fix, so I omitted creating an issue.