### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/publish_backup.yaml
+++ b/.github/workflows/publish_backup.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566  # v3
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/secrets_scan.yaml
+++ b/.github/workflows/secrets_scan.yaml
@@ -21,9 +21,9 @@ jobs:
             echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           fi
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{env.branch}}
           fetch-depth: ${{env.depth}}
       - name: Scan for secrets
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@6bd2d14f7a4bc1e569fa3550efa7ec632a4fa67b  # main

--- a/.github/workflows/test_ryzenai_modeling.yaml
+++ b/.github/workflows/test_ryzenai_modeling.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/hf-workflows/.github/workflows/ryzenai_ci.yaml@main
+    uses: huggingface/hf-workflows/.github/workflows/ryzenai_ci.yaml@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
     with:
       pytest_marker: "not prequantized_model_test"
       test_file: "tests/ryzenai/test_modeling.py"

--- a/.github/workflows/test_ryzenai_nightly.yaml
+++ b/.github/workflows/test_ryzenai_nightly.yaml
@@ -11,14 +11,14 @@ concurrency:
 
 jobs:
   run_tests_prequantized_models:
-    uses: huggingface/hf-workflows/.github/workflows/ryzenai_ci.yaml@main
+    uses: huggingface/hf-workflows/.github/workflows/ryzenai_ci.yaml@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
     with:
       pytest_marker: "prequantized_model_test"
       test_file: "tests/ryzenai/test_modeling.py"
       report_name: "tests_prequantized_models"
       
   run_tests_quantization:
-    uses: huggingface/hf-workflows/.github/workflows/ryzenai_ci.yaml@main
+    uses: huggingface/hf-workflows/.github/workflows/ryzenai_ci.yaml@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
     with:
       pytest_marker: "quant_test"
       test_file: "tests/ryzenai/test_quantization.py"
@@ -36,9 +36,9 @@ jobs:
       run_tests_quantization,
     ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3
         with:
           path: ./reports/
       - name: Send message to Slack
@@ -58,7 +58,7 @@ jobs:
       # Upload complete failure tables, as they might be big and only truncated versions could be sent to Slack.
       - name: Failure table artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
         with:
           name: prev_ci_results
           path: prev_ci_results

--- a/.github/workflows/test_zentorch_plugin.yaml
+++ b/.github/workflows/test_zentorch_plugin.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: [self-hosted, amd-cpu, epyc, genoa]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Copy zentorch binary to current directory
         run: cp
@@ -37,7 +37,7 @@ jobs:
           docker/transformers-pytorch-amd-cpu-zentorch
 
       - name: Run tests
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185  # v3
         with:
           image: optimum-amd-zentorch:2.2.1
           options: |

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       package_name: optimum-amd
     secrets:


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `secrets_scan.yaml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `secrets_scan.yaml` | `trufflesecurity/trufflehog` | `main` | `main` | `6bd2d14f7a4b…` |
| `test_ryzenai_nightly.yaml` | `huggingface/hf-workflows/.github/workflows/ryzenai_ci.yaml` | `main` | `main` | `a88e7fa2eaee…` |
| `test_ryzenai_nightly.yaml` | `huggingface/hf-workflows/.github/workflows/ryzenai_ci.yaml` | `main` | `main` | `a88e7fa2eaee…` |
| `test_ryzenai_nightly.yaml` | `actions/checkout` | `v3` | `v6.0.2` | `de0fac2e4500…` |
| `test_ryzenai_nightly.yaml` | `actions/download-artifact` | `v3` | `v3` | `9bc31d5ccc31…` |
| `test_ryzenai_nightly.yaml` | `actions/upload-artifact` | `v3` | `v3` | `ff15f0306b3f…` |
| `publish_backup.yaml` | `actions/setup-python` | `v3` | `v3` | `3542bca2639a…` |
| `test_zentorch_plugin.yaml` | `actions/checkout` | `v3` | `v6.0.2` | `de0fac2e4500…` |
| `test_zentorch_plugin.yaml` | `addnab/docker-run-action` | `v3` | `v3` | `4f65fabd2431…` |
| `upload_pr_documentation.yml` | `huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `test_ryzenai_modeling.yaml` | `huggingface/hf-workflows/.github/workflows/ryzenai_ci.yaml` | `main` | `main` | `a88e7fa2eaee…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#224